### PR TITLE
Use layer id (not object) in relations; YAML2QGS

### DIFF
--- a/dataobjects/layers.py
+++ b/dataobjects/layers.py
@@ -22,21 +22,24 @@ from qgis.core import QgsVectorLayer, QgsDataSourceUri
 
 
 class Layer:
-    def __init__(self, provider, uri):
+    def __init__(self, provider, uri, id=None):
         self.provider = provider
         self.uri = uri
+        self.inner_id = self.inner_id() if id is None else id
         self.__layer = None
 
     def dump(self):
         definition = dict()
         definition['provider'] = self.provider
         definition['uri'] = self.uri
+        definition['innerId'] = self.inner_id
 
         return definition
 
     def load(self, definition):
         self.provider = definition['provider']
         self.uri = definition['uri']
+        self.inner_id = definition['innerId']
 
     def create(self):
         if not self.__layer:
@@ -47,3 +50,12 @@ class Layer:
 
     def table_name(self):
         return QgsDataSourceUri(self.uri).table()
+
+    def inner_id(self):
+        dsu = QgsDataSourceUri(self.uri)
+        return "${}.{}".format(dsu.schema(),dsu.table())
+
+    def id(self):
+        if not self.__layer:
+            self.create()
+        return self.__layer.id()

--- a/dataobjects/relations.py
+++ b/dataobjects/relations.py
@@ -24,12 +24,24 @@ class Relation(object):
         self.referenced_layer = definition['referencedLayer']
         self.referenced_field = definition['referencedField']
 
-    def create(self):
+    def create(self, layers):
         print('Creating relation')
         relation = QgsRelation()
-        relation.setRelationId(self.name)
-        relation.setRelationName(self.name)
-        relation.setReferencingLayer(self.referencing_layer.create().id())
-        relation.setReferencedLayer(self.referenced_layer.create().id())
+        if not self.name:
+            self.name = "{}_{}".format(self.referencing_layer, self.referencing_field)
+        relation.setId(self.name)
+        relation.setName(self.name)
+
+        found = 0
+        for layer in layers:
+            if layer.inner_id == self.referencing_layer:
+                relation.setReferencingLayer(layer.id())
+                found += 1
+            if layer.inner_id == self.referenced_layer:
+                relation.setReferencedLayer(layer.id())
+                found += 1
+            if found == 2:
+                break
+
         relation.addFieldPair( self.referencing_field, self.referenced_field)
         return relation

--- a/generator/postgres/relations.py
+++ b/generator/postgres/relations.py
@@ -29,8 +29,8 @@ class PostgresRelation(Relation):
             print ('Checking relation')
             if record['referencing_table_name'] in mapped_layers.keys() and record['referenced_table_name'] in mapped_layers.keys():
                 relation = Relation()
-                relation.referencing_layer = mapped_layers[record['referencing_table_name']]
-                relation.referenced_layer = mapped_layers[record['referenced_table_name']]
+                relation.referencing_layer = mapped_layers[record['referencing_table_name']].inner_id
+                relation.referenced_layer = mapped_layers[record['referenced_table_name']].inner_id
                 relation.referencing_field = record['referencing_column_name']
                 relation.referenced_field = record['referenced_column_name']
                 relation.name = record['constraint_name']

--- a/metaproject.py
+++ b/metaproject.py
@@ -57,7 +57,7 @@ def main(argv):
     project.relations = relations
 
     qgis_project = QgsProject.instance()
-    project.create(args.out, qgis_project)
+    project.create(args.out + '.qgs', qgis_project)
 
     yamlfile = args.out + '.yaml'
     with open(yamlfile, 'w') as f:
@@ -66,6 +66,39 @@ def main(argv):
 
     QgsApplication.exitQgis()
 
+def yaml2qgs(argv):
+    parser = argparse.ArgumentParser('Generate QGIS project from a YAML file.')
+    parser.add_argument("--yaml", type=str, help='Path to input YAML. (Example: /home/qgis/my_yaml.yaml)')
+    parser.add_argument("out", type=str, help='Path to the generated dataobjects. (Example: /home/qgis/my_project)')
+
+    args = parser.parse_args()
+
+    # Initialize qgis libraries
+    app = QgsApplication([], True)
+    QgsApplication.initQgis()
+
+    def debug_log_message(message, tag, level):
+        #print('{}({}): {}'.format(tag, level, message))
+        pass
+
+    QgsApplication.instance().messageLog().messageReceived.connect(debug_log_message)
+
+    with open(args.yaml) as f:
+        yamlfile = f.read()
+
+    if not yamlfile:
+        return
+
+    definition = yaml.load(yamlfile)
+    project = Project()
+    project.load(definition)
+
+    qgis_project = QgsProject.instance()
+    project.create(args.out + '.qgs', qgis_project)
+
+    QgsApplication.exitQgis()
+
 if __name__ == "__main__":
     # execute only if run as a script
     main(sys.argv[1:])
+    #yaml2qgs(sys.argv[1:])


### PR DESCRIPTION
+ In generated YAML files, avoid using layer objects and use instead layer inner ids in 'relations' section. After all, layer objects are already defined in 'legend' section.
+ Support YAML2QGS operation from the command line. You need to comment/uncomment lines in the bottom of metaproject.py to toggle modes.

Using layer ids should ease both YAML merging and layer grouping.