### PR TITLE
Optimize layer tree grouping (avoid moving layers)

### DIFF
--- a/projectgenerator/libqgsprojectgen/dataobjects/legend.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/legend.py
@@ -57,6 +57,5 @@ class LegendGroup(object):
                 subgroup = group.addGroup(item.name)
                 item.create(qgis_project, subgroup)
             else:
-                node = qgis_project.layerTreeRoot().findLayer(item.real_id)
-                group.addChildNode(node.clone())
-                node.parent().removeChildNode(node)
+                layer = qgis_project.mapLayer(item.real_id)
+                group.addLayer(layer)

--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -78,7 +78,7 @@ class Project(QObject):
 
             qgis_layers.append(qgis_layer)
 
-        qgis_project.addMapLayers(qgis_layers)
+        qgis_project.addMapLayers(qgis_layers, False)
 
         if isinstance(self.crs, QgsCoordinateReferenceSystem):
             qgis_project.setCrs(self.crs)
@@ -95,8 +95,7 @@ class Project(QObject):
 
         qgis_project.setCrs(self.crs)
 
-        if self.legend:
-            self.legend.create(qgis_project)
+        self.legend.create(qgis_project)
 
         if path:
             qgis_project.write(path)

--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -78,7 +78,7 @@ class Project(QObject):
 
             qgis_layers.append(qgis_layer)
 
-        qgis_project.addMapLayers(qgis_layers, False)
+        qgis_project.addMapLayers(qgis_layers, not self.legend)
 
         if isinstance(self.crs, QgsCoordinateReferenceSystem):
             qgis_project.setCrs(self.crs)
@@ -95,7 +95,8 @@ class Project(QObject):
 
         qgis_project.setCrs(self.crs)
 
-        self.legend.create(qgis_project)
+        if self.legend:
+            self.legend.create(qgis_project)
 
         if path:
             qgis_project.write(path)


### PR DESCRIPTION
Moving layers takes a while, perhaps due to layer cloning. 
This PR improves our use case (+200 tables) in almost 40 seconds (from 2m23s to 1m42s).