### PR TITLE
Handle some potential errors

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -64,6 +64,13 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
     def accepted(self):
         configuration = self.updated_configuration()
 
+        if not configuration.host:
+            self.txtStdout.setText(self.tr('Please set a host before creating the project.'))
+            return
+        if not configuration.database:
+            self.txtStdout.setText(self.tr('Please set a database before creating the project.'))
+            return
+
         if self.type_combo_box.currentData() == 'ili':
             importer = iliimporter.Importer()
 
@@ -135,12 +142,12 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         """
         configuration = iliimporter.Configuration()
 
-        configuration.host = self.pg_host_line_edit.text()
-        configuration.user = self.pg_user_line_edit.text()
-        configuration.database = self.pg_database_line_edit.text()
-        configuration.schema = self.pg_schema_line_edit.text()
+        configuration.host = self.pg_host_line_edit.text().strip()
+        configuration.user = self.pg_user_line_edit.text().strip()
+        configuration.database = self.pg_database_line_edit.text().strip()
+        configuration.schema = self.pg_schema_line_edit.text().strip()
         configuration.password = self.pg_password_line_edit.text()
-        configuration.ilifile = self.ili_file_line_edit.text()
+        configuration.ilifile = self.ili_file_line_edit.text().strip()
         configuration.epsg = self.epsg
         configuration.inheritance = self.ili2pg_options.get_inheritance_type()
         configuration.java_path = QSettings().value('QgsProjectGenerator/java_path', '')

--- a/projectgenerator/libili2pg/iliimporter.py
+++ b/projectgenerator/libili2pg/iliimporter.py
@@ -121,7 +121,9 @@ class Importer(QObject):
             # By default try JAVA_HOME and PATH
             java_paths = []
             if 'JAVA_HOME' in os.environ:
-                java_paths += [os.path.join(os.environ['JAVA_HOME'], 'java')]
+                paths = os.environ['JAVA_HOME'].split(";")
+                for path in paths:
+                    java_paths += [os.path.join(path.replace("\"","").replace("'",""), 'java')]
             java_paths += ['java']
 
         proc = None

--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -80,10 +80,12 @@ class Project(QObject):
 
         qgis_project.addMapLayers(qgis_layers, not self.legend)
 
-        if isinstance(self.crs, QgsCoordinateReferenceSystem):
-            qgis_project.setCrs(self.crs)
-        else:
-            qgis_project.setCrs(QgsCoordinateReferenceSystem.fromEpsgId(self.crs))
+        if self.crs:
+            if isinstance(self.crs, QgsCoordinateReferenceSystem):
+                qgis_project.setCrs(self.crs)
+            else:
+                qgis_project.setCrs(QgsCoordinateReferenceSystem.fromEpsgId(self.crs))
+
 
         qgis_relations = list(qgis_project.relationManager().relations().values())
         for relation in self.relations:
@@ -92,8 +94,6 @@ class Project(QObject):
             qgis_relations.append(rel)
 
         qgis_project.relationManager().setRelations(qgis_relations)
-
-        qgis_project.setCrs(self.crs)
 
         if self.legend:
             self.legend.create(qgis_project)

--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -86,7 +86,6 @@ class Project(QObject):
             else:
                 qgis_project.setCrs(QgsCoordinateReferenceSystem.fromEpsgId(self.crs))
 
-
         qgis_relations = list(qgis_project.relationManager().relations().values())
         for relation in self.relations:
             rel = relation.create()


### PR DESCRIPTION
- On Windows, I've come across JAVA_HOME paths that come with quotes and need to be cleaned before we append 'java' to build the executable path. 

- If we load a model with no geometry tables, CRS would not be specified.

- PostgreSQL database connection issues are mostly handled by ili2pg. However, an empty host or database passes through ili2pg silently and throws an error when Generator attempts to establish connection.