### PR TITLE
Handle some potential errors

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -64,6 +64,13 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
     def accepted(self):
         configuration = self.updated_configuration()
 
+        if not configuration.host:
+            self.txtStdout.setText(self.tr('Please set a host before creating the project.'))
+            return
+        if not configuration.database:
+            self.txtStdout.setText(self.tr('Please set a database before creating the project.'))
+            return
+
         if self.type_combo_box.currentData() == 'ili':
             importer = iliimporter.Importer()
 
@@ -135,12 +142,12 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         """
         configuration = iliimporter.Configuration()
 
-        configuration.host = self.pg_host_line_edit.text()
-        configuration.user = self.pg_user_line_edit.text()
-        configuration.database = self.pg_database_line_edit.text()
-        configuration.schema = self.pg_schema_line_edit.text()
+        configuration.host = self.pg_host_line_edit.text().strip()
+        configuration.user = self.pg_user_line_edit.text().strip()
+        configuration.database = self.pg_database_line_edit.text().strip()
+        configuration.schema = self.pg_schema_line_edit.text().strip()
         configuration.password = self.pg_password_line_edit.text()
-        configuration.ilifile = self.ili_file_line_edit.text()
+        configuration.ilifile = self.ili_file_line_edit.text().strip()
         configuration.epsg = self.epsg
         configuration.inheritance = self.ili2pg_options.get_inheritance_type()
         configuration.java_path = QSettings().value('QgsProjectGenerator/java_path', '')

--- a/projectgenerator/libili2pg/iliimporter.py
+++ b/projectgenerator/libili2pg/iliimporter.py
@@ -121,7 +121,7 @@ class Importer(QObject):
             # By default try JAVA_HOME and PATH
             java_paths = []
             if 'JAVA_HOME' in os.environ:
-                paths = os.environ['JAVA_HOME'].split(";")
+                paths = os.environ['JAVA_HOME'].split(os.pathsep)
                 for path in paths:
                     java_paths += [os.path.join(path.replace("\"","").replace("'",""), 'java')]
             java_paths += ['java']

--- a/projectgenerator/libili2pg/iliimporter.py
+++ b/projectgenerator/libili2pg/iliimporter.py
@@ -121,7 +121,9 @@ class Importer(QObject):
             # By default try JAVA_HOME and PATH
             java_paths = []
             if 'JAVA_HOME' in os.environ:
-                java_paths += [os.path.join(os.environ['JAVA_HOME'], 'java')]
+                paths = os.environ['JAVA_HOME'].split(";")
+                for path in paths:
+                    java_paths += [os.path.join(path.replace("\"","").replace("'",""), 'java')]
             java_paths += ['java']
 
         proc = None

--- a/projectgenerator/libili2pg/iliimporter.py
+++ b/projectgenerator/libili2pg/iliimporter.py
@@ -3,7 +3,7 @@ import os
 import re
 import tempfile
 import zipfile
-
+import locale
 import functools
 
 from qgis.PyQt.QtCore import QObject, pyqtSignal, QProcess, QEventLoop
@@ -61,6 +61,7 @@ class Importer(QObject):
         QObject.__init__(self, parent)
         self.filename = None
         self.configuration = Configuration()
+        self.encoding = locale.getlocale()[1]
 
     def run(self):
         dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -154,7 +155,7 @@ class Importer(QObject):
         return self.__result
 
     def stderr_ready(self, proc):
-        text = bytes(proc.readAllStandardError()).decode()
+        text = bytes(proc.readAllStandardError()).decode(self.encoding)
         if not self.__done_pattern:
             self.__done_pattern = re.compile(r"Info: ...done")
         if self.__done_pattern.search(text):
@@ -164,5 +165,5 @@ class Importer(QObject):
         pass
 
     def stdout_ready(self, proc):
-        text = bytes(proc.readAllStandardOutput()).decode()
+        text = bytes(proc.readAllStandardOutput()).decode(self.encoding)
         self.stdout.emit(text)

--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -80,10 +80,12 @@ class Project(QObject):
 
         qgis_project.addMapLayers(qgis_layers, not self.legend)
 
-        if isinstance(self.crs, QgsCoordinateReferenceSystem):
-            qgis_project.setCrs(self.crs)
-        else:
-            qgis_project.setCrs(QgsCoordinateReferenceSystem.fromEpsgId(self.crs))
+        if self.crs:
+            if isinstance(self.crs, QgsCoordinateReferenceSystem):
+                qgis_project.setCrs(self.crs)
+            else:
+                qgis_project.setCrs(QgsCoordinateReferenceSystem.fromEpsgId(self.crs))
+
 
         qgis_relations = list(qgis_project.relationManager().relations().values())
         for relation in self.relations:
@@ -92,8 +94,6 @@ class Project(QObject):
             qgis_relations.append(rel)
 
         qgis_project.relationManager().setRelations(qgis_relations)
-
-        qgis_project.setCrs(self.crs)
 
         if self.legend:
             self.legend.create(qgis_project)

--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -86,7 +86,6 @@ class Project(QObject):
             else:
                 qgis_project.setCrs(QgsCoordinateReferenceSystem.fromEpsgId(self.crs))
 
-
         qgis_relations = list(qgis_project.relationManager().relations().values())
         for relation in self.relations:
             rel = relation.create()

--- a/projectgenerator/qgs_project_generator.py
+++ b/projectgenerator/qgs_project_generator.py
@@ -17,6 +17,8 @@
  *                                                                         *
  ***************************************************************************/
 """
+import locale
+
 from projectgenerator.gui.generate_project import GenerateProjectDialog
 from qgis.PyQt.QtWidgets import QAction, QMenu
 from qgis.PyQt.QtCore import QObject
@@ -28,6 +30,8 @@ class QgsProjectGeneratorPlugin(QObject):
         self.iface = iface
         self.__generate_action = None
         self.__configure_action = None
+        if locale.getlocale() == (None, None):
+            locale.setlocale(locale.LC_ALL, '')
 
     def initGui(self):
         self.__generate_action = QAction(self.tr('Generate'), None)

--- a/projectgenerator/utils/qt_utils.py
+++ b/projectgenerator/utils/qt_utils.py
@@ -29,6 +29,7 @@ from qgis.PyQt.QtCore import (
     QEventLoop,
     QUrl
 )
+from qgis.PyQt.QtGui import QValidator
 from qgis.PyQt.QtNetwork import QNetworkRequest
 from qgis.core import QgsNetworkAccessManager
 from functools import partial
@@ -89,3 +90,21 @@ def download_file(url, filename, on_progress=None):
         raise NetworkError(reply.error(), reply.errorMessage)
     else:
         return filename
+
+
+class Validators(QObject):
+    def validate_line_edits(self, *args, **kwargs):
+        """
+        Validate line edits and set their color to indicate validation state.
+        """
+        senderObj = self.sender()
+        validator = senderObj.validator()
+        state = validator.validate(senderObj.text().strip(), 0)[0]
+        if state == QValidator.Acceptable:
+            color = '#fff' # White
+        elif state == QValidator.Intermediate:
+            color = '#ffd356' # Light orange
+        else:
+            color = '#f6989d' # Red
+        senderObj.setStyleSheet('QLineEdit {{ background-color: {} }}'.format(color))
+

--- a/projectgenerator/utils/qt_utils.py
+++ b/projectgenerator/utils/qt_utils.py
@@ -19,6 +19,7 @@
  ***************************************************************************/
 """
 
+import os.path
 import inspect
 from qgis.PyQt.QtWidgets import QFileDialog
 from qgis.PyQt.QtCore import (
@@ -33,6 +34,7 @@ from qgis.PyQt.QtGui import QValidator
 from qgis.PyQt.QtNetwork import QNetworkRequest
 from qgis.core import QgsNetworkAccessManager
 from functools import partial
+
 
 def selectFolder(line_edit_widget, title, file_filter, parent):
     filename, matched_filter = QFileDialog.getOpenFileName(parent, title, line_edit_widget.text(), file_filter)
@@ -107,4 +109,15 @@ class Validators(QObject):
         else:
             color = '#f6989d' # Red
         senderObj.setStyleSheet('QLineEdit {{ background-color: {} }}'.format(color))
+
+
+class FileValidator(QValidator):
+    """
+    Validator for file line edits
+    """
+    def validate(self, text, pos):
+        if not text or not os.path.isfile(text) or not text.endswith('.ili'):
+            return (QValidator.Intermediate, text, pos)
+        else:
+            return (QValidator.Acceptable, text, pos)
 


### PR DESCRIPTION
  -  On Windows, I've come across JAVA_HOME paths that come with quotes and need to be cleaned before we append 'java' to build the executable path.

 -  If we load a model with no geometry tables, CRS would not be specified.

 - Use psycopg2 to catch errors with PostgreSQL database connections. Empty host/database/user are handled via `QRegExpValidator` and communicated to the user, first through an orange color in the corresponding line edit, and, after clicking on `Create`, through a message and control focus.

 - Subclass `QValidator` (`FileValidator`) to validate input Interlis files.
 
 - Make sure we set an encoding for `decode()` functions in iliimporter.py Otherwise, we get `UnicodeDecodeError`'s.