### PR TITLE
Domain configuration

### DIFF
--- a/projectgenerator/libqgsprojectgen/dataobjects/layers.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/layers.py
@@ -46,6 +46,8 @@ class Layer:
         if not self.__layer:
             layer_name = self.table_name
             self.__layer = QgsVectorLayer(self.uri, layer_name, self.provider)
+            if self.is_domain:
+                self.__layer.setReadOnly()
 
         for field in self.fields:
             field.create(self)

--- a/projectgenerator/libqgsprojectgen/dataobjects/layers.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/layers.py
@@ -22,22 +22,25 @@ from qgis.core import QgsVectorLayer, QgsDataSourceUri, QgsWkbTypes
 
 
 class Layer:
-    def __init__(self, provider, uri):
+    def __init__(self, provider, uri, is_domain=False):
         self.provider = provider
         self.uri = uri
         self.__layer = None
         self.fields = list()
+        self.is_domain = is_domain
 
     def dump(self):
         definition = dict()
         definition['provider'] = self.provider
         definition['uri'] = self.uri
+        definition['isdomain'] = self.is_domain
 
         return definition
 
     def load(self, definition):
         self.provider = definition['provider']
         self.uri = definition['uri']
+        self.is_domain = definition['isdomain']
 
     def create(self):
         if not self.__layer:

--- a/projectgenerator/libqgsprojectgen/dataobjects/legend.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/legend.py
@@ -21,9 +21,10 @@
 from qgis.core import QgsProject
 
 class LegendGroup(object):
-    def __init__(self, name=None):
+    def __init__(self, name=None, expanded=True):
         self.name = name
         self.items = list()
+        self.expanded = expanded
 
     def dump(self):
         definition = list()
@@ -55,7 +56,11 @@ class LegendGroup(object):
         for item in self.items:
             if isinstance(item, LegendGroup):
                 subgroup = group.addGroup(item.name)
+                subgroup.setExpanded(item.expanded)
                 item.create(qgis_project, subgroup)
             else:
                 layer = qgis_project.mapLayer(item.real_id)
                 group.addLayer(layer)
+
+    def is_empty(self):
+        return not bool(self.items)

--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -20,7 +20,7 @@
 
 from .layers import Layer
 from .legend import LegendGroup
-from qgis.core import QgsCoordinateReferenceSystem, QgsProject
+from qgis.core import QgsCoordinateReferenceSystem, QgsProject, QgsEditorWidgetSetup
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 
 
@@ -86,10 +86,21 @@ class Project(QObject):
             qgis_project.setCrs(QgsCoordinateReferenceSystem.fromEpsgId(self.crs))
 
         qgis_relations = list(qgis_project.relationManager().relations().values())
+        dict_domains = {layer.real_id: layer.is_domain for layer in self.layers}
         for relation in self.relations:
             rel = relation.create()
             assert rel.isValid()
             qgis_relations.append(rel)
+
+            if dict_domains[rel.referencedLayerId()]:
+                editor_widget_setup = QgsEditorWidgetSetup('RelationReference', {
+                        'Relation': rel.id(),
+                        'ShowForm': False,
+                        'OrderByValue': True
+                    }
+                )
+                referencing_layer = rel.referencingLayer()
+                referencing_layer.setEditorWidgetSetup(rel.referencingFields()[0], editor_widget_setup)
 
         qgis_project.relationManager().setRelations(qgis_relations)
 

--- a/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
@@ -187,7 +187,7 @@ WHERE st.relid = '{schema}.{table}'::regclass;
     def legend(self, layers):
         legend = LegendGroup('root')
         tables = LegendGroup('tables')
-        domains = LegendGroup('domains')
+        domains = LegendGroup('domains', False)
 
         point_layers = []
         line_layers = []
@@ -217,6 +217,7 @@ WHERE st.relid = '{schema}.{table}'::regclass;
             legend.append(l)
 
         legend.append(tables)
-        legend.append(domains)
+        if not domains.is_empty():
+            legend.append(domains)
 
         return legend

--- a/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
@@ -186,8 +186,8 @@ WHERE st.relid = '{schema}.{table}'::regclass;
 
     def legend(self, layers):
         legend = LegendGroup('root')
-
         tables = LegendGroup('tables')
+        domains = LegendGroup('domains')
 
         point_layers = []
         line_layers = []
@@ -204,7 +204,10 @@ WHERE st.relid = '{schema}.{table}'::regclass;
                     polygon_layers.append(layer)
 
             else:
-                tables.append(layer)
+                if layer.is_domain:
+                    domains.append(layer)
+                else:
+                    tables.append(layer)
 
         for l in point_layers:
             legend.append(l)
@@ -214,5 +217,6 @@ WHERE st.relid = '{schema}.{table}'::regclass;
             legend.append(l)
 
         legend.append(tables)
+        legend.append(domains)
 
         return legend


### PR DESCRIPTION
1. Determine whether a table is a domain
   - Only possible if metadata table (see https://github.com/claeis/ili2db/issues/63#issuecomment-290627830) exists
   - If a schema is given, only query such schema 
2. Configure Relation Reference for domains (this may be reverted when embedded forms are disabled by default in QGIS)
3. Create layer-tree group for domains
4. Make domain tables read-only and collapse domains group
   - Avoid adding domains group if no domains are found

References #18
References #8