### PR TITLE
Update to ili2pg v3.9.1

### DIFF
--- a/projectgenerator/libili2pg/ili2pg_config.py
+++ b/projectgenerator/libili2pg/ili2pg_config.py
@@ -19,7 +19,7 @@
 """
 from qgis.PyQt.QtCore import QObject
 
-ILI2PG_VERSION = '3.8.1'
+ILI2PG_VERSION = '3.9.1'
 ILI2PG_URL = 'http://www.eisenhutinformatik.ch/interlis/ili2pg/ili2pg-{}.zip'.format(ILI2PG_VERSION)
 
 class BaseConfiguration(object):

--- a/projectgenerator/libili2pg/iliimporter.py
+++ b/projectgenerator/libili2pg/iliimporter.py
@@ -11,7 +11,7 @@ from qgis.PyQt.QtCore import QObject, pyqtSignal, QProcess, QEventLoop
 from projectgenerator.libili2pg.ili2pg_config import ImportConfiguration
 from projectgenerator.utils.qt_utils import download_file
 
-ILI2PG_VERSION = '3.8.1'
+ILI2PG_VERSION = '3.9.1'
 ILI2PG_URL = 'http://www.eisenhutinformatik.ch/interlis/ili2pg/ili2pg-{}.zip'.format(ILI2PG_VERSION)
 
 
@@ -111,6 +111,8 @@ class Importer(QObject):
         args += ["--coalesceMultiSurface"]
         args += ["--createGeomIdx"]
         args += ["--createFk"]
+        args += ["--setupPgExt"]
+        args += ["--createMetaInfo"]
         if self.configuration.inheritance == 'smart1':
             args += ["--smart1Inheritance"]
         else:

--- a/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
@@ -59,7 +59,7 @@ class PostgresCreator:
                 is_domain_field = "p.setting AS is_domain,"
                 domain_left_join = """LEFT JOIN {}.t_ili2db_table_prop p
                               ON p.tablename = tbls.tablename
-                              AND p.tag = 'is_domain'""".format(self.schema)
+                              AND p.tag = 'ch.ehi.ili2db.tableKind'""".format(self.schema)
             schema_where = "AND schemaname = '{}'".format(self.schema)
 
         cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
@@ -119,7 +119,7 @@ class PostgresCreator:
                     table=record['tablename']
                 )
 
-            layer = Layer('postgres', data_source_uri, bool(record['is_domain']) if 'is_domain' in record else False)
+            layer = Layer('postgres', data_source_uri, record['is_domain'] == 'ENUM' or record['is_domain'] == 'CATALOGUE' if 'is_domain' in record else False)
 
             # Get all fields for this table
             fields_cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)

--- a/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
@@ -124,14 +124,19 @@ class PostgresCreator:
             # Get all fields for this table
             fields_cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
             fields_cur.execute("""
-            SELECT
-  c.column_name,
-  pgd.description AS comment
-FROM pg_catalog.pg_statio_all_tables st
-LEFT JOIN information_schema.columns c ON c.table_schema=st.schemaname AND c.table_name=st.relname
-LEFT JOIN pg_catalog.pg_description pgd ON pgd.objoid=st.relid AND pgd.objsubid=c.ordinal_position
-WHERE st.relid = '{schema}.{table}'::regclass;
+                SELECT
+                  c.column_name,
+                  pgd.description AS comment,
+                  unit.setting AS unit,
+                  txttype.setting AS texttype
+                FROM pg_catalog.pg_statio_all_tables st
+                LEFT JOIN information_schema.columns c ON c.table_schema=st.schemaname AND c.table_name=st.relname
+                LEFT JOIN pg_catalog.pg_description pgd ON pgd.objoid=st.relid AND pgd.objsubid=c.ordinal_position
+                LEFT JOIN {schema}.t_ili2db_column_prop unit ON c.table_name=unit.tablename AND c.column_name=unit.columname AND unit.tag = 'ch.ehi.ili2db.unit'
+                LEFT JOIN {schema}.t_ili2db_column_prop txttype ON c.table_name=txttype.tablename AND c.column_name=txttype.columname AND txttype.tag = 'ch.ehi.ili2db.textKind'
+                WHERE st.relid = '{schema}.{table}'::regclass;
             """.format(schema=record['schemaname'], table=record['tablename']))
+
 
             # Get all 'c'heck constraints for this table
             constraints_cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
@@ -173,9 +178,13 @@ WHERE st.relid = '{schema}.{table}'::regclass;
                     field.widget = 'Range'
                     field.widget_config['Min'] = constraint_mapping[column_name][0]
                     field.widget_config['Max'] = constraint_mapping[column_name][1]
+                    field.widget_config['Suffix'] = fielddef['unit'] if 'unit' in fielddef else ''
+
+                if 'texttype' in fielddef and fielddef['texttype'] == 'MTEXT':
+                    field.widget = 'TextEdit'
+                    field.widget_config['IsMultiline'] = True
 
                 layer.fields.append(field)
-
 
             layers.append(layer)
 


### PR DESCRIPTION
- Add 2 new parameters to --schemaimport:
  - --setupPgExt: see https://github.com/claeis/ili2db/issues/81
  - --createMetaInfo: see https://github.com/claeis/ili2db/issues/63

- Add support for Units and MTEXT

- Update domain recognition: be aware of the tag 'ch.ehi.ili2db.tableKind' and its relevant values for domains (ENUM and CATALOGUE). See https://github.com/claeis/ili2db/commit/64a9b1411df35f103d8ab4b9895e1f0fcacdcbd5.

Fix #49