### PR TITLE
Random fixes

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -34,7 +34,7 @@ from qgis.PyQt.QtGui import QColor, QDesktopServices, QFont, QRegExpValidator, Q
 from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QApplication
 from qgis.PyQt.QtCore import QCoreApplication, QSettings, QRegExp, Qt
 from qgis.core import QgsProject, QgsCoordinateReferenceSystem
-from qgis.gui import QgsProjectionSelectionDialog
+from qgis.gui import QgsProjectionSelectionDialog, QgsMessageBar
 from ..utils import get_ui_class
 from ..libili2pg import iliimporter
 from ..libqgsprojectgen.generator.postgres import Generator
@@ -85,8 +85,9 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.pg_user_line_edit.textChanged.emit(self.pg_user_line_edit.text())
         self.ili_file_line_edit.textChanged.connect(self.validators.validate_line_edits)
         self.ili_file_line_edit.textChanged.emit(self.ili_file_line_edit.text())
-        self.ilicache = IliCache(self.iface, base_config)
+        self.ilicache = IliCache(base_config)
         self.ilicache.models_changed.connect(self.update_models_completer)
+        self.ilicache.new_message.connect(self.show_message)
         self.ilicache.refresh()
 
     def accepted(self):
@@ -279,3 +280,9 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         completer = QCompleter(self.ilicache.model_names)
         completer.setCaseSensitivity(Qt.CaseInsensitive)
         self.ili_models_line_edit.setCompleter(completer)
+
+    def show_message(self, level, message):
+        if level == QgsMessageBar.WARNING:
+            self.iface.messageBar().pushWarning(self.tr('Project Generator'), message)
+        elif level == QgsMessageBar.CRITICAL:
+            self.iface.messageBar().pushCritical(self.tr('Project Generator'), message)

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -44,9 +44,10 @@ DIALOG_UI = get_ui_class('generate_project.ui')
 
 
 class GenerateProjectDialog(QDialog, DIALOG_UI):
-    def __init__(self, base_config, parent=None):
+    def __init__(self, iface, base_config, parent=None):
         QDialog.__init__(self, parent)
         self.setupUi(self)
+        self.iface = iface
         self.buttonBox.accepted.disconnect()
         self.buttonBox.accepted.connect(self.accepted)
         self.buttonBox.clear()
@@ -84,7 +85,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.pg_user_line_edit.textChanged.emit(self.pg_user_line_edit.text())
         self.ili_file_line_edit.textChanged.connect(self.validators.validate_line_edits)
         self.ili_file_line_edit.textChanged.emit(self.ili_file_line_edit.text())
-        self.ilicache = IliCache(base_config)
+        self.ilicache = IliCache(self.iface, base_config)
         self.ilicache.models_changed.connect(self.update_models_completer)
         self.ilicache.refresh()
 

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -163,7 +163,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.buttonBox.clear()
         self.buttonBox.setEnabled(True)
         self.buttonBox.addButton(QDialogButtonBox.Close)
-        
+
         QApplication.restoreOverrideCursor()
 
     def print_info(self, text):
@@ -179,7 +179,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
     def on_process_started(self, command):
         self.txtStdout.setText(command)
         QCoreApplication.processEvents()
- 
+
     def on_process_finished(self, exit_code, result):
         self.txtStdout.setTextColor(QColor('#777777'))
         self.txtStdout.append('Finished ({})'.format(exit_code))
@@ -194,7 +194,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         configuration.host = self.pg_host_line_edit.text().strip()
         configuration.user = self.pg_user_line_edit.text().strip()
         configuration.database = self.pg_database_line_edit.text().strip()
-        configuration.schema = self.pg_schema_line_edit.text().strip()
+        configuration.schema = self.pg_schema_line_edit.text().strip().lower()
         configuration.password = self.pg_password_line_edit.text()
         configuration.ilifile = self.ili_file_line_edit.text().strip()
         configuration.ilimodels = self.ili_models_line_edit.text().strip()

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -244,8 +244,10 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
     def type_changed(self):
         if self.type_combo_box.currentData() == 'ili':
             self.ili_config.show()
+            self.pg_schema_line_edit.setPlaceholderText("[Leave empty to create a default schema]")
         else:
             self.ili_config.hide()
+            self.pg_schema_line_edit.setPlaceholderText("[Leave empty to load all schemas in the database]")
 
     def link_activated(self, link):
         if link.url() == '#configure':

--- a/projectgenerator/libili2pg/ilicache.py
+++ b/projectgenerator/libili2pg/ilicache.py
@@ -130,28 +130,43 @@ class IliCache(QObject):
         '''
         Parses all .ili files in the given ``path`` (non-recursively)
         '''
-        model = dict()
+        models = list()
+        fileModels = list()
+        for ilifile in glob.iglob(os.path.join(path, '*.ili')):
+            try:
+                fileModels = self.parse_ili_file(ilifile, "utf-8")
+            except UnicodeDecodeError:
+                try:
+                    fileModels = self.parse_ili_file(ilifile, "latin1")
+                except UnicodeDecodeError:
+                    QgsMessageLog.logMessage(self.tr('Could not parse ili file `{ilifile}`. We suggest you to encode it in UTF-8. ({exception})'.format(ilifile=ilifile, exception=str(e))), self.tr('Projectgenerator'))
+
+            models.extend(fileModels)
+
+        self.repositories[path] = sorted(models, key=lambda m: m['version'], reverse=True)
+        self.models_changed.emit()
+
+    def parse_ili_file(self, ilipath, encoding):
+        '''
+        Parses an ili file returning models and version data
+        '''
         models = list()
         re_model = re.compile('\s*MODEL\s*([\w\d_-]+)\s.*')
         re_model_version = re.compile('VERSION "([ \w\d\._-]+)".*')
+        with open(ilipath, 'r', encoding=encoding) as file:
+            for line in file:
+                result = re_model.search(line)
+                if result:
+                    model = dict()
+                    model['name'] = result.group(1)
+                    model['version'] = ''
+                    models += [model]
 
-        for ilifile in glob.iglob(os.path.join(path, '*.ili')):
-            with open(ilifile, 'r') as file:
-                for line in file:
-                    result = re_model.search(line)
-                    if result:
-                        model = dict()
-                        model['name'] = result.group(1)
-                        model['version'] = ''
-                        models += [model]
+                result = re_model_version.search(line)
+                if result:
+                    model['version'] = result.group(1)
 
-                    result = re_model_version.search(line)
-                    if result:
-                        model['version'] = result.group(1)
-
-        print(repr(models[0]['name']))
-        self.repositories[path] = sorted(models, key=lambda m: m['version'], reverse=True)
-        self.models_changed.emit()
+        return models
 
     @property
     def model_names(self):

--- a/projectgenerator/libili2pg/ilicache.py
+++ b/projectgenerator/libili2pg/ilicache.py
@@ -37,10 +37,10 @@ class IliCache(QObject):
     }
 
     models_changed = pyqtSignal()
+    new_message = pyqtSignal(int, str)
 
-    def __init__(self, iface, configuration):
+    def __init__(self, configuration):
         QObject.__init__(self)
-        self.iface = iface
         self.cache_path = os.path.expanduser('~/.ilicache')
         self.repositories = dict()
         self.base_configuration = configuration
@@ -140,10 +140,10 @@ class IliCache(QObject):
             except UnicodeDecodeError:
                 try:
                     fileModels = self.parse_ili_file(ilifile, "latin1")
-                    self.iface.messageBar().pushWarning(self.tr('Project Generator'),
+                    self.new_message.emit(QgsMessageBar.WARNING,
                         self.tr('Even though the ili file `{}` could be read, it is not in UTF-8. Please encode your ili models in UTF-8.'.format(os.path.basename(ilifile))))
                 except UnicodeDecodeError:
-                    self.iface.messageBar().pushCritical(self.tr('Project Generator'),
+                    self.new_message.emit(QgsMessageBar.CRITICAL,
                         self.tr('Could not parse ili file `{}` with UTF-8 nor Latin-1 encodings. Please encode your ili models in UTF-8.'.format(os.path.basename(ilifile))))
                     QgsMessageLog.logMessage(self.tr('Could not parse ili file `{ilifile}`. We suggest you to encode it in UTF-8. ({exception})'.format(ilifile=ilifile, exception=str(e))), self.tr('Projectgenerator'))
 

--- a/projectgenerator/libili2pg/ilicache.py
+++ b/projectgenerator/libili2pg/ilicache.py
@@ -141,7 +141,7 @@ class IliCache(QObject):
                 try:
                     fileModels = self.parse_ili_file(ilifile, "latin1")
                     self.iface.messageBar().pushWarning(self.tr('Project Generator'),
-                        self.tr('Could not parse ili file `{}` with UTF-8 encoding. Please encode your ili models in UTF-8.'.format(os.path.basename(ilifile))))
+                        self.tr('Even though the ili file `{}` could be read, it is not in UTF-8. Please encode your ili models in UTF-8.'.format(os.path.basename(ilifile))))
                 except UnicodeDecodeError:
                     self.iface.messageBar().pushCritical(self.tr('Project Generator'),
                         self.tr('Could not parse ili file `{}` with UTF-8 nor Latin-1 encodings. Please encode your ili models in UTF-8.'.format(os.path.basename(ilifile))))

--- a/projectgenerator/libili2pg/ilicache.py
+++ b/projectgenerator/libili2pg/ilicache.py
@@ -28,6 +28,7 @@ import re
 from projectgenerator.utils.qt_utils import download_file, NetworkError
 from PyQt5.QtCore import QObject, pyqtSignal
 from qgis.core import QgsMessageLog
+from qgis.gui import QgsMessageBar
 
 
 class IliCache(QObject):
@@ -37,8 +38,9 @@ class IliCache(QObject):
 
     models_changed = pyqtSignal()
 
-    def __init__(self, configuration):
+    def __init__(self, iface, configuration):
         QObject.__init__(self)
+        self.iface = iface
         self.cache_path = os.path.expanduser('~/.ilicache')
         self.repositories = dict()
         self.base_configuration = configuration
@@ -138,7 +140,11 @@ class IliCache(QObject):
             except UnicodeDecodeError:
                 try:
                     fileModels = self.parse_ili_file(ilifile, "latin1")
+                    self.iface.messageBar().pushWarning(self.tr('Project Generator'),
+                        self.tr('Could not parse ili file `{}` with UTF-8 encoding. Please encode your ili models in UTF-8.'.format(os.path.basename(ilifile))))
                 except UnicodeDecodeError:
+                    self.iface.messageBar().pushCritical(self.tr('Project Generator'),
+                        self.tr('Could not parse ili file `{}` with UTF-8 nor Latin-1 encodings. Please encode your ili models in UTF-8.'.format(os.path.basename(ilifile))))
                     QgsMessageLog.logMessage(self.tr('Could not parse ili file `{ilifile}`. We suggest you to encode it in UTF-8. ({exception})'.format(ilifile=ilifile, exception=str(e))), self.tr('Projectgenerator'))
 
             models.extend(fileModels)

--- a/projectgenerator/libili2pg/iliimporter.py
+++ b/projectgenerator/libili2pg/iliimporter.py
@@ -130,13 +130,13 @@ class Importer(QObject):
         if self.configuration.epsg != 21781:
             args += ["--defaultSrsCode", "{}".format(self.configuration.epsg)]
 
+        args += self.configuration.base_configuration.to_ili2db_args()
+
         if self.configuration.ilimodels:
             args += ['--models', self.configuration.ilimodels]
 
         if self.configuration.ilifile:
             args += [self.configuration.ilifile]
-
-        args += self.configuration.base_configuration.to_ili2db_args()
 
         if self.configuration.java_path:
             # A java path is configured: respect it no mather what

--- a/projectgenerator/qgs_project_generator.py
+++ b/projectgenerator/qgs_project_generator.py
@@ -59,7 +59,7 @@ class QgsProjectGeneratorPlugin(QObject):
         del self.__generate_action
 
     def show_generate_dialog(self):
-        dlg = GenerateProjectDialog(self.ili2db_configuration)
+        dlg = GenerateProjectDialog(self.iface, self.ili2db_configuration)
         dlg.exec_()
 
     def show_options_dialog(self):


### PR DESCRIPTION
1. Adjust `placeholderText` for schema according to current mode (Interlis/PostGIS).
2. Parse local ili models with `utf-8` encoding. If that fails (`UnicodeDecodeError`), try with 'latin-1'. If that still fails, log it and continue silently. 
3. Since ili2pg creates the schema in lower case, deal with lower-case schemas in Project Generator. Otherwise, the plugin won't be able to load tables from the database when using schemas with capital letters.
4. Send ili file parameter to the end of the command.