### PR TITLE
Automatic configuration of domains-class QGIS relations

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -111,7 +111,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             return
 
         try:
-            generator = Generator(configuration.uri, configuration.schema)
+            generator = Generator(configuration.uri, configuration.schema, configuration.inheritance)
         except OperationalError:
             self.txtStdout.setText(self.tr('There was an error connecting to the database. Check connection parameters.'))
             return
@@ -163,7 +163,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.buttonBox.clear()
         self.buttonBox.setEnabled(True)
         self.buttonBox.addButton(QDialogButtonBox.Close)
-        
+
         QApplication.restoreOverrideCursor()
 
     def print_info(self, text):
@@ -179,7 +179,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
     def on_process_started(self, command):
         self.txtStdout.setText(command)
         QCoreApplication.processEvents()
- 
+
     def on_process_finished(self, exit_code, result):
         self.txtStdout.setTextColor(QColor('#777777'))
         self.txtStdout.append('Finished ({})'.format(exit_code))

--- a/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
@@ -269,4 +269,4 @@ class DomainRelation(Relation):
 # TODO
 # Not yet supported:
 #   Classes that don't belong to a topic but directly to the model
-#   Classes that extend other classes don't get base class attributes
+#   smart1Inheritance

--- a/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
@@ -18,78 +18,123 @@
  ***************************************************************************/
 """
 import re
+import psycopg2
+
+from projectgenerator.libqgsprojectgen.dataobjects.relations import Relation
 
 class DomainRelation(Relation):
-    pass
+    def __init__(self):
+        pass
 
-    @classmethod
-    def find_domain_relations(cls, domains, conn, schema):
+    def find_domain_relations(self, layers, conn, schema):
+        domains = [layer.table_name for layer in layers if layer.is_domain]
+        print("domains:",domains)
+        if not domains:
+            return []
 
+        mapped_layers = {layer.table_name : layer for layer in layers}
+
+        # Map domain ili name with its correspondent pg name
         cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
-
         domain_names = "'" + "','".join(domains) + "'"
         cur.execute("""SELECT iliname, sqlname
                         FROM {schema}.t_ili2db_classname
                         WHERE sqlname IN ({domain_names})
                     """.format(schema=schema, domain_names=domain_names))
-
-        relations = list()
         domains_ili_pg = dict()
-
         for record in cur:
             domains_ili_pg[record['iliname']] = record['sqlname']
-
+        print("domains_ili_pg:",domains_ili_pg)
 
         # Get MODELS
         cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
-
-        domain_names = "'" + "','".join(domains) + "'"
         cur.execute("""SELECT modelname, content
-                       FROM {schema}.t_ili2db_model)
-                    """.format(schema=schema, domain_names=domain_names))
+                       FROM {schema}.t_ili2db_model
+                    """.format(schema=schema))
         models = dict()
         models_info = dict()
         for record in cur:
             models[record['modelname'].split("{")[0]] = record['content']
+        # TODO To get info from base classes we might need to discover a dependency tree right here
+        print("models:",models)
         for k,v in models.items():
             models_info.update(self.parse_model(v, domains))
+        print("Classes with domain attrs:",len(models_info))
 
+        # Map class ili name with its correspondent pg name
+        cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        class_names = "'" + "','".join(list(models_info.keys())) + "'"
+        cur.execute("""SELECT *
+                       FROM {schema}.t_ili2db_classname
+                       WHERE iliname IN ({class_names})
+                    """.format(schema=schema, class_names=class_names))
+        classes_ili_pg = dict()
+        for record in cur:
+            classes_ili_pg[record['iliname']] = record['sqlname']
+        print("classes_ili_pg:",classes_ili_pg)
 
-            #relation = Relation()
-            #relation.referencing_layer = mapped_layers[record['referencing_table_name']]
-            #relation.referenced_layer = mapped_layers[record['referenced_table_name']]
-            #relation.referencing_field = record['referencing_column_name']
-            #relation.referenced_field = record['referenced_column_name']
-            #relation.name = record['constraint_name']
+        # Map attr ili name with its correspondent pg name
+        cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        all_attrs = list()
+        for c, dict_attr_domain in models_info.items():
+            all_attrs.extend(list[dict_attr_domain.keys()])
+        attr_names = "'" + "','".join(all_attrs) + "'"
+        cur.execute("""SELECT iliname, sqlname
+                       FROM {schema}.t_ili2db_attrname
+                       WHERE iliname IN ({attr_names})
+                    """.format(schema=schema, attr_names=attr_names))
+        attrs_ili_pg = dict()
+        for record in cur:
+            attrs_ili_pg[record['iliname']] = record['sqlname']
+        print("attrs_ili_pg:",attrs_ili_pg)
 
-            #relations.append(relation)
+        # Create relations
+        relations = list()
+        for iliclass, dict_attr_domain in models_info.items():
+            for iliattr, ilidomain in dict_attr_domain:
+                if iliclass in classes_ili_pg and ilidomain in domains_ili_pg and iliattr in attrs_ili_pg:
+                    relation = Relation()
+                    relation.referencing_layer = mapped_layers[classes_ili_pg[iliclass]]
+                    relation.referenced_layer = mapped_layers[classes_ili_pg[ilidomain]]
+                    relation.referencing_field = attrs_ili_pg[iliattr]
+                    relation.referenced_field = 'itfcode'
+                    #relation.name = record['constraint_name']
 
+                    relations.append(relation)
+
+        print("final_models_info:",models_info)
+        print("Num of Relations:",len(relations))
         return relations
 
-
     def parse_model(self, model_content, domains):
-        re_model = re.compile('\s*MODEL\s*([\w\d_-]+)\s.*') # MODEL Catastro_COL_ES_V_2_0_20170331 (es)
-        re_topic = re.compile('\s*TOPIC\s*([\w\d_-]+)\s.*') # TOPIC Catastro_Registro [=]
-        re_class = re.compile('\s*CLASS\s*([\w\d_-]+)\s.*') # CLASS ClassName [=]
+        re_model = re.compile('\s*MODEL\s*([\w\d_-]+).*') # MODEL Catastro_COL_ES_V_2_0_20170331 (es)
+        re_topic = re.compile('\s*TOPIC\s*([\w\d_-]+).*') # TOPIC Catastro_Registro [=]
+        re_class = re.compile('\s*CLASS\s*([\w\d_-]+).*') # CLASS ClassName [=]
         re_end_class = None  # END ClassName;
         re_end_topic = None # END TopicName;
+        re_end_model = None # END ModelName;
 
         current_model = ''
         current_topic = ''
         current_class = ''
         attributes = dict()
         models_info = dict()
-        for line in model_content:
+        for line in model_content.splitlines():
             if not current_model:
                 result = re_model.search(line)
                 if result:
                     current_model = result.group(1)
+                    re_end_model = re.compile('\s*END\s*{}\..*'.format(current_model)) # END TopicName; # FIX
             else: # The is a current_model
                 if not current_topic:
                   result = re_topic.search(line)
                   if result:
                       current_topic = result.group(1)
-                      re_end_topic = re.compile('\s*END\s*{}\s*;\s.*'.format(current_topic)) # END TopicName;
+                      re_end_topic = re.compile('\s*END\s*{}\s*;.*'.format(current_topic)) # END TopicName;
+
+                      local_names = self.extract_local_names_from_domains(domains, current_model, current_topic)
+                      domains_with_local = [name for name_list in local_names.values() for name in name_list] + domains
+
                       continue
                 else: # There is a current_topic
                     if not current_class: # Go for classes
@@ -97,20 +142,21 @@ class DomainRelation(Relation):
                         if result:
                             current_class = result.group(1)
                             attributes = dict()
-                            re_end_class = re.compile('\s*END\s*{}\s*;\s.*'.format(current_class))  # END ClassName;
+                            re_end_class = re.compile('\s*END\s*{}*;.*'.format(current_class))  # END ClassName;
                             continue
                     else: # There is a current_class, go for attributes
-                        local_names = extract_local_names_from_domains(domains, current_model, current_topic)
-                        domains_with_local = [name for name_list in local_names.values() for name in name_list] + domains
-                        attribute = {res.group(1):d for d in domains_with_local for res in [re.search('\s*([\w\d_-]+).*:.*\s{}.*'.format(d),line)] if res}
+                        attribute = {res.group(1):d for d in domains_with_local for res in [re.search('\s*([\w\d_-]+).*:.*\s{};'.format(d),line)] if res}
 
                         if attribute:
+                            old_key = list(attribute.keys())[0] # Not qualified name
+                            new_key = "{}.{}.{}.{}".format(current_model, current_topic, current_class, old_key) # Fully qualified name
                             attr_value = list(attribute.values())[0]
                             if attr_value not in domains: # Match was vs. local name, find its corresponding qualified name
                                 for k,v in local_names.items():
                                     if attr_value in v:
-                                        attribute[list(attribute.keys())[0]] = k
+                                        attribute[old_key] = k
                                         break
+                            attribute[new_key] = attribute.pop(old_key)
                             attributes.update(attribute)
                             continue
 
@@ -125,8 +171,11 @@ class DomainRelation(Relation):
                     if result:
                         current_topic = ''
 
-        return models_info
+                result = re_end_model.search(line)
+                if result:
+                    current_model = ''
 
+        return models_info
 
     def extract_local_names_from_domains(self, domains, current_model, current_topic):
         """
@@ -153,3 +202,7 @@ class DomainRelation(Relation):
         return local_names
 
 
+# TODO
+# Not yet supported:
+#   Classes that don't belong to a topic but directly to the model
+#   Classes that extend other classes don't get base class attributes

--- a/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
@@ -253,7 +253,13 @@ class DomainRelation(Relation):
 
     def get_ext_dom_attrs(self, iliclass, models_info, extended_classes, inheritance):
         if inheritance == 'smart1':
-            return self.get_ext_dom_attrs_smart1(iliclass, models_info, extended_classes)
+            # Use smart 2 first to get domain attributes from parents (we really need them) and only then use smart 1
+            tmp_models_info = models_info
+            if iliclass in tmp_models_info:
+                tmp_models_info[iliclass].update( self.get_ext_dom_attrs_smart2(iliclass, models_info, extended_classes) )
+            else:
+                tmp_models_info[iliclass] = self.get_ext_dom_attrs_smart2(iliclass, models_info, extended_classes)
+            return self.get_ext_dom_attrs_smart1(iliclass, tmp_models_info, extended_classes)
         elif inheritance == 'smart2':
             return self.get_ext_dom_attrs_smart2(iliclass, models_info, extended_classes)
         else: # No smart inheritance?

--- a/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
@@ -111,7 +111,7 @@ class DomainRelation(Relation):
         for iliclass, dict_attr_domain in models_info_with_ext.items():
             for iliattr, ilidomain in dict_attr_domain.items():
                 if iliclass in classes_ili_pg and ilidomain in domains_ili_pg and iliattr in attrs_ili:
-                    if classes_ili_pg[iliclass] in mapped_layers and domains_ili_pg[ilidomain] in mapped_layers:
+                    if classes_ili_pg[iliclass] in mapped_layers and domains_ili_pg[ilidomain] in mapped_layers and classes_ili_pg[iliclass] in attrs_ili_pg_owner:
                         # Might be that due to ORM mapping, a class is not in mapped_layers
                         relation = Relation()
                         relation.referencing_layer = mapped_layers[classes_ili_pg[iliclass]]

--- a/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
@@ -116,8 +116,8 @@ class DomainRelation(Relation):
                         relation.referencing_layer = mapped_layers[classes_ili_pg[iliclass]]
                         relation.referenced_layer = mapped_layers[domains_ili_pg[ilidomain]]
                         relation.referencing_field = attrs_ili_pg_owner[classes_ili_pg[iliclass]][iliattr]
-                        relation.referenced_field = 'itfcode'
-                        relation.name = "{}_{}_{}_{}".format(classes_ili_pg[iliclass],attrs_ili_pg_owner[classes_ili_pg[iliclass]][iliattr],domains_ili_pg[ilidomain],'itfcode')
+                        relation.referenced_field = 'ilicode'
+                        relation.name = "{}_{}_{}_{}".format(classes_ili_pg[iliclass],attrs_ili_pg_owner[classes_ili_pg[iliclass]][iliattr],domains_ili_pg[ilidomain],'ilicode')
 
                         relations.append(relation)
 

--- a/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+                              -------------------
+        begin                : 12/07/17
+        git sha              : :%H$
+        copyright            : (C) 2017 by Germán Carrillo
+        email                : gcarrillo@linuxmail.org
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+import re
+
+class DomainRelation(Relation):
+    pass
+
+    @classmethod
+    def find_domain_relations(cls, domains, conn, schema):
+
+        cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+        domain_names = "'" + "','".join(domains) + "'"
+        cur.execute("""SELECT iliname, sqlname
+                        FROM {schema}.t_ili2db_classname
+                        WHERE sqlname IN ({domain_names})
+                    """.format(schema=schema, domain_names=domain_names))
+
+        relations = list()
+        domains_ili_pg = dict()
+
+        for record in cur:
+            domains_ili_pg[record['iliname']] = record['sqlname']
+
+
+        # Get MODELS
+        cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+        domain_names = "'" + "','".join(domains) + "'"
+        cur.execute("""SELECT modelname, content
+                       FROM {schema}.t_ili2db_model)
+                    """.format(schema=schema, domain_names=domain_names))
+        models = dict()
+        models_info = dict()
+        for record in cur:
+            models[record['modelname'].split("{")[0]] = record['content']
+        for k,v in models.items():
+            models_info.update(self.parse_model(v, domains))
+
+
+            #relation = Relation()
+            #relation.referencing_layer = mapped_layers[record['referencing_table_name']]
+            #relation.referenced_layer = mapped_layers[record['referenced_table_name']]
+            #relation.referencing_field = record['referencing_column_name']
+            #relation.referenced_field = record['referenced_column_name']
+            #relation.name = record['constraint_name']
+
+            #relations.append(relation)
+
+        return relations
+
+
+    def parse_model(self, model_content, domains):
+        re_model = re.compile('\s*MODEL\s*([\w\d_-]+)\s.*') # MODEL Catastro_COL_ES_V_2_0_20170331 (es)
+        re_topic = re.compile('\s*TOPIC\s*([\w\d_-]+)\s.*') # TOPIC Catastro_Registro [=]
+        re_class = re.compile('\s*CLASS\s*([\w\d_-]+)\s.*') # CLASS ClassName [=]
+        re_end_class = None  # END ClassName;
+        re_end_topic = None # END TopicName;
+
+        current_model = ''
+        current_topic = ''
+        current_class = ''
+        attributes = dict()
+        models_info = dict()
+        for line in model_content:
+            if not current_model:
+                result = re_model.search(line)
+                if result:
+                    current_model = result.group(1)
+            else: # The is a current_model
+                if not current_topic:
+                  result = re_topic.search(line)
+                  if result:
+                      current_topic = result.group(1)
+                      re_end_topic = re.compile('\s*END\s*{}\s*;\s.*'.format(current_topic)) # END TopicName;
+                      continue
+                else: # There is a current_topic
+                    if not current_class: # Go for classes
+                        result = re_class.search(line)
+                        if result:
+                            current_class = result.group(1)
+                            attributes = dict()
+                            re_end_class = re.compile('\s*END\s*{}\s*;\s.*'.format(current_class))  # END ClassName;
+                            continue
+                    else: # There is a current_class, go for attributes
+                        local_names = extract_local_names_from_domains(domains, current_model, current_topic)
+                        domains_with_local = [name for name_list in local_names.values() for name in name_list] + domains
+                        attribute = {res.group(1):d for d in domains_with_local for res in [re.search('\s*([\w\d_-]+).*:.*\s{}.*'.format(d),line)] if res}
+
+                        if attribute:
+                            attr_value = list(attribute.values())[0]
+                            if attr_value not in domains: # Match was vs. local name, find its corresponding qualified name
+                                for k,v in local_names.items():
+                                    if attr_value in v:
+                                        attribute[list(attribute.keys())[0]] = k
+                                        break
+                            attributes.update(attribute)
+                            continue
+
+                        result = re_end_class.search(line)
+                        if result:
+                            if attributes:
+                                models_info.update({'{}.{}.{}'.format(current_model,current_topic,current_class) : attributes})
+                            current_class = ''
+                            continue
+
+                    result = re_end_topic.search(line)
+                    if result:
+                        current_topic = ''
+
+        return models_info
+
+
+    def extract_local_names_from_domains(self, domains, current_model, current_topic):
+        """
+        ili files may contain fully qualified domains assigned to attributes, but if
+        domains are local (domain or topic-wise), domains might be assigned only
+        with its name. This function builds local names (with no model and topic
+        name, or without model name) for each domain name in 'domains' input. For
+        instance: from a domain name "MODEL.TOPIC.DOMAIN", this function returns
+        {MODEL: [DOMAIN, TOPIC.DOMAIN]} Order is relevant, since later matches in a
+        search will overwrite previous ones (better to preserve more-qualified
+        matches).
+        """
+        local_names = dict()
+        for domain in domains:
+            local_names_list = list()
+            if domain.startswith('{}.'.format(current_model)) or domain.startswith('{}.{}.'.format(current_model, current_topic)):
+                array = domain.split(".")
+                if len(array) > 0:
+                    local_names_list.append(array[-1])
+                if len(array) > 1:
+                    local_names_list.append('{}.{}'.format(array[-2], array[-1]))
+                if local_names_list:
+                    local_names[domain] = local_names_list
+        return local_names
+
+

--- a/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
@@ -32,12 +32,13 @@ from .domain_relations import DomainRelation
 
 
 class PostgresCreator:
-    def __init__(self, uri, schema):
+    def __init__(self, uri, schema, inheritance):
         assert 'postgres' in QgsProviderRegistry.instance().providerList(), 'postgres provider not found in {}. Is the QGIS_PREFIX_PATH properly set?'.format(
             QgsProviderRegistry.instance().providerList())
         self.uri = uri
         self.schema = schema
         self.conn = psycopg2.connect(uri)
+        self.inheritance = inheritance
 
     def layers(self):
         bMetadataTable = False
@@ -196,7 +197,7 @@ class PostgresCreator:
         # Automatic domain generation
         # We won't need this when https://github.com/claeis/ili2db/issues/19 is solved!
         domainRelation = DomainRelation()
-        domain_relations = domainRelation.find_domain_relations(layers, self.conn, self.schema)
+        domain_relations = domainRelation.find_domain_relations(layers, self.conn, self.schema, self.inheritance)
 
         return relations + domain_relations
 

--- a/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
@@ -195,12 +195,10 @@ class PostgresCreator:
         relations =  PostgresRelation.find_relations(layers, self.conn, self.schema)
         # Automatic domain generation
         # We won't need this when https://github.com/claeis/ili2db/issues/19 is solved!
-        domains = [layer.table_name for layer in layers if layer.is_domain]
-        if domains:
-            domain_relations = DomainRelation.find_domain_relations(domains, self.conn, self.schema)
-            relations.update(domain_relations)
+        domainRelation = DomainRelation()
+        domain_relations = domainRelation.find_domain_relations(layers, self.conn, self.schema)
 
-        return relations
+        return relations + domain_relations
 
     def legend(self, layers):
         legend = LegendGroup('root')

--- a/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/postgrescreator.py
@@ -28,6 +28,7 @@ from projectgenerator.libqgsprojectgen.dataobjects.layers import Layer
 from qgis.core import QgsProviderRegistry, QgsWkbTypes
 from .config import IGNORED_SCHEMAS, IGNORED_TABLES, IGNORED_FIELDNAMES, READONLY_FIELDNAMES
 from .relations import PostgresRelation
+from .domain_relations import DomainRelation
 
 
 class PostgresCreator:
@@ -191,7 +192,15 @@ class PostgresCreator:
         return layers
 
     def relations(self, layers):
-        return PostgresRelation.find_relations(layers, self.conn, self.schema)
+        relations =  PostgresRelation.find_relations(layers, self.conn, self.schema)
+        # Automatic domain generation
+        # We won't need this when https://github.com/claeis/ili2db/issues/19 is solved!
+        domains = [layer.table_name for layer in layers if layer.is_domain]
+        if domains:
+            domain_relations = DomainRelation.find_domain_relations(domains, self.conn, self.schema)
+            relations.update(domain_relations)
+
+        return relations
 
     def legend(self, layers):
         legend = LegendGroup('root')


### PR DESCRIPTION
This PR enables Project Generator to automatically configure QGIS relations for Domain-Class pairs.
This approach should be temporary, as ili2pg will support Domain-Class FKs in v4.0 https://github.com/claeis/ili2db/issues/19

This PR doesn't set FKs in the database, but uses QGIS relations, and works for smart1Inheritance and smart2Inheritance.

References #8