### PR TITLE
Fix 3 issues with domain-class relations

### DIFF
--- a/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
@@ -66,8 +66,10 @@ class DomainRelation(Relation):
         if self.debug: print("Classes with domain attrs:", len(models_info))
 
         # Map class ili name with its correspondent pg name
+        # Take into account classes with domain attrs and those that extend other classes,
+        #   because parent classes might have domain attrs that will be transfered to children
         cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
-        class_names = "'" + "','".join(list(models_info.keys())) + "'"
+        class_names = "'" + "','".join(list(models_info.keys())+list(extended_classes.keys())) + "'"
         cur.execute("""SELECT *
                        FROM {schema}.t_ili2db_classname
                        WHERE iliname IN ({class_names})
@@ -129,7 +131,7 @@ class DomainRelation(Relation):
                             if self.debug: print("Relation:", relation.name)
                             relations.append(relation)
 
-        if self.debug: print("final_models_info:", models_info)
+        if self.debug: print("final_models_info:", models_info_with_ext)
         if self.debug: print("extended_classes:", extended_classes)
         if self.debug: print("Num of Relations:", len(relations))
         return relations

--- a/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
@@ -313,10 +313,21 @@ class DomainRelation(Relation):
             return models_info[iliclass] if iliclass in models_info else {}
         all_attrs = models_info[iliclass] if iliclass in models_info else {}
 
+        unqualified_attrs = {k.split(".")[-1]: k for k in all_attrs.keys()}
+
         for parents_domain_attr, domain in parents_domain_attrS.items():
-            # smart2Inheritance: Pass parent attributes to child, but omit already existing attrs (they are extended already)
-            if parents_domain_attr not in all_attrs:
+            # smart2Inheritance: Pass parent attributes to child if they are missing.
+            # If they exist, overwrite keys (i.e., parent_domain_attr: child_domain)
+            parents_unqualified_attr = parents_domain_attr.split(".")[-1]
+
+            if parents_unqualified_attr not in unqualified_attrs:
                 all_attrs[parents_domain_attr] = domain
+            else: # Extended, use parent's attribute name with child domain name
+                if unqualified_attrs[parents_unqualified_attr] in all_attrs:
+                    tmpDomain = all_attrs[unqualified_attrs[parents_unqualified_attr]]
+                    del all_attrs[unqualified_attrs[parents_unqualified_attr]]
+                    all_attrs[parents_domain_attr] = tmpDomain
+
         return all_attrs
 
 # TODO

--- a/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
+++ b/projectgenerator/libqgsprojectgen/generator/postgres/domain_relations.py
@@ -195,7 +195,7 @@ class DomainRelation(Relation):
                                 continue
 
                         attribute = {res.group(1): d for d in domains_with_local for res in
-                                     [re.search('\s*([\w\d_-]+).*:.*\s{}.*'.format(d), line)] if res}
+                                     [re.search('\s*([\w\d_-]+).*:.*\s{};.*'.format(d), line)] if res}
 
                         if attribute:
                             if self.debug: print("MATCH:", attribute)


### PR DESCRIPTION
 - Wrong assignation of domains if one name is contained in the other (ej: dom1 and dom10) (fixed REGEXP).
 - Wrong treatment of extended attrs (fixed smart2 function to bring parent's attr name and pair it with child domain).
 - Missing domain attributes inherited from parents and not extended in child class (fixed list of potential referencing classes by adding classes that extend other classes).