### PR TITLE
Fix in Export

### DIFF
--- a/projectgenerator/libili2pg/ili2pg_config.py
+++ b/projectgenerator/libili2pg/ili2pg_config.py
@@ -38,10 +38,11 @@ class BaseConfiguration(object):
         self.custom_model_directories = settings.value('CustomModelDirectories', '', str)
         self.java_path = settings.value('JavaPath', '', str)
 
-    def to_ili2db_args(self):
+    def to_ili2db_args(self, export_modeldir=True):
         args = []
-        if self.custom_model_directories_enabled and self.custom_model_directories:
-            args += ['--modeldir', self.custom_model_directories]
+        if export_modeldir:
+            if self.custom_model_directories_enabled and self.custom_model_directories:
+                args += ['--modeldir', self.custom_model_directories]
         return args
 
     @property

--- a/projectgenerator/libili2pg/iliexporter.py
+++ b/projectgenerator/libili2pg/iliexporter.py
@@ -92,6 +92,8 @@ class Exporter(QObject):
         args += ["--dbdatabase", self.configuration.database]
         args += ["--dbschema", self.configuration.schema or self.configuration.database]
 
+        args += self.configuration.base_configuration.to_ili2db_args(False)
+
         if self.configuration.ilimodels:
             args += ['--models', self.configuration.ilimodels]
 

--- a/projectgenerator/libili2pg/iliexporter.py
+++ b/projectgenerator/libili2pg/iliexporter.py
@@ -92,8 +92,6 @@ class Exporter(QObject):
         args += ["--dbdatabase", self.configuration.database]
         args += ["--dbschema", self.configuration.schema or self.configuration.database]
 
-        args += self.configuration.base_configuration.to_ili2db_args()
-
         if self.configuration.ilimodels:
             args += ['--models', self.configuration.ilimodels]
 


### PR DESCRIPTION
`modeldir` param is not needed for Export, `ili2db` will get models from the database itself (table `t_ili2db_model`)