### PR TITLE
Make 'public' the default schema

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -113,6 +113,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             self.pg_user_line_edit.setFocus()
             return
 
+        configuration.schema = configuration.schema or 'public'
         try:
             generator = Generator(configuration.uri, configuration.schema, configuration.inheritance)
             print('uri: {} schema: {} inheritance: {}'.format(configuration.uri, configuration.schema, configuration.inheritance))
@@ -148,8 +149,6 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
                         'Java could not be found. Please <a href="https://java.com/en/download/">install Java</a> and or <a href="#configure">configure a custom java path</a>. We also support the JAVA_HOME environment variable in case you prefer this.'))
                     self.enable()
                     return
-
-                configuration.schema = configuration.schema or configuration.database
 
             available_layers = generator.layers()
             relations = generator.relations(available_layers)
@@ -250,7 +249,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             self.pg_schema_line_edit.setPlaceholderText(self.tr("[Leave empty to create a default schema]"))
         else:
             self.ili_config.hide()
-            self.pg_schema_line_edit.setPlaceholderText(self.tr("[Leave empty to load all schemas in the database]"))
+            self.pg_schema_line_edit.setPlaceholderText(self.tr("[Leave empty to load the default schema 'public']"))
 
     def link_activated(self, link):
         if link.url() == '#configure':

--- a/projectgenerator/libili2pg/iliexporter.py
+++ b/projectgenerator/libili2pg/iliexporter.py
@@ -90,7 +90,7 @@ class Exporter(QObject):
         if self.configuration.password:
             args += ["--dbpwd", self.configuration.password]
         args += ["--dbdatabase", self.configuration.database]
-        args += ["--dbschema", self.configuration.schema or self.configuration.database]
+        args += ["--dbschema", self.configuration.schema or 'public']
 
         args += self.configuration.base_configuration.to_ili2db_args()
 

--- a/projectgenerator/libili2pg/iliimporter.py
+++ b/projectgenerator/libili2pg/iliimporter.py
@@ -93,7 +93,7 @@ class Importer(QObject):
         if self.configuration.password:
             args += ["--dbpwd", self.configuration.password]
         args += ["--dbdatabase", self.configuration.database]
-        args += ["--dbschema", self.configuration.schema or self.configuration.database]
+        args += ["--dbschema", self.configuration.schema or 'public']
         args += ["--createEnumTabs"]
         args += ["--createNumChecks"]
         args += ["--coalesceMultiSurface"]

--- a/projectgenerator/ui/export.ui
+++ b/projectgenerator/ui/export.ui
@@ -55,7 +55,7 @@
           <item row="4" column="2">
            <widget class="QLineEdit" name="pg_schema_line_edit">
             <property name="placeholderText">
-             <string>[Leave empty to load all schemas in the database]</string>
+             <string>[Leave empty to export the default schema 'public']</string>
             </property>
            </widget>
           </item>

--- a/projectgenerator/ui/generate_project.ui
+++ b/projectgenerator/ui/generate_project.ui
@@ -55,7 +55,7 @@
           <item row="4" column="2">
            <widget class="QLineEdit" name="pg_schema_line_edit">
             <property name="placeholderText">
-             <string>[Leave empty to load all schemas in the database]</string>
+             <string>[Leave empty to load the default schema 'public']</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
The current behavior, i.e., using database name as default schema, causes confusion to users. 