### PR TITLE
Radiobutton for model and Interlis file

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -236,7 +236,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         settings.setValue('QgsProjectGenerator/ili2pg/database', configuration.database)
         settings.setValue('QgsProjectGenerator/ili2pg/schema', configuration.schema)
         settings.setValue('QgsProjectGenerator/ili2pg/password', configuration.password)
-        settings.setValue('QgsProjectGenerator/ili2pg/modelenabled', self.model_radio_button.isChecked())
+        settings.setValue('QgsProjectGenerator/ili2db/UseModels', self.model_radio_button.isChecked())
         settings.setValue('QgsProjectGenerator/importtype', self.type_combo_box.currentData())
 
     def restore_configuration(self):
@@ -257,7 +257,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.type_changed()
         self.crs_changed()
 
-        checked_radio = settings.value('QgsProjectGenerator/ili2pg/modelenabled', True, bool)
+        checked_radio = settings.value('QgsProjectGenerator/ili2db/UseModels', True, bool)
         self.model_radio_button.setChecked(True) if checked_radio else self.interlis_file_radio_button.setChecked(True)
 
     def disable(self):

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -79,6 +79,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.pg_host_line_edit.setValidator(nonEmptyValidator)
         self.pg_database_line_edit.setValidator(nonEmptyValidator)
         self.pg_user_line_edit.setValidator(nonEmptyValidator)
+        self.ili_models_line_edit.setValidator(nonEmptyValidator)
 
         self.pg_host_line_edit.textChanged.connect(self.validators.validate_line_edits)
         self.pg_host_line_edit.textChanged.emit(self.pg_host_line_edit.text())
@@ -86,10 +87,14 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.pg_database_line_edit.textChanged.emit(self.pg_database_line_edit.text())
         self.pg_user_line_edit.textChanged.connect(self.validators.validate_line_edits)
         self.pg_user_line_edit.textChanged.emit(self.pg_user_line_edit.text())
+        self.ili_models_line_edit.textChanged.connect(self.validators.validate_line_edits)
+        self.ili_models_line_edit.textChanged.emit(self.ili_file_line_edit.text())
         self.ilicache = IliCache(base_config)
         self.ilicache.models_changed.connect(self.update_models_completer)
         self.ilicache.new_message.connect(self.show_message)
         self.ilicache.refresh()
+        self.radio_button_1.toggled.connect(self.radio1_clicked)
+        self.radio_button_2.toggled.connect(self.radio2_clicked)
 
     def accepted(self):
         configuration = self.updated_configuration()
@@ -291,3 +296,29 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             self.bar.pushMessage(message, QgsMessageBar.INFO, 10)
         elif level == QgsMessageBar.CRITICAL:
             self.bar.pushMessage(message, QgsMessageBar.WARNING, 10)
+
+    def radio1_clicked(self, enabled):
+        if enabled:
+            self.ili_models_line_edit.setEnabled(True)
+            nonEmptyValidator = NonEmptyStringValidator()
+            self.ili_models_line_edit.setValidator(nonEmptyValidator)
+            self.ili_models_line_edit.textChanged.connect(self.validators.validate_line_edits)
+            self.ili_models_line_edit.textChanged.emit(self.ili_file_line_edit.text())
+            self.ili_file_line_edit.setEnabled(False)
+            self.ili_file_browse_button.setEnabled(False)
+            self.ili_file_line_edit.setText("")
+            self.ili_file_line_edit.setValidator(None)
+            self.ili_file_line_edit.setStyleSheet('QLineEdit {{ background-color: {} }}'.format('#fff'))
+
+    def radio2_clicked(self, enabled):
+        if enabled:
+            self.ili_file_line_edit.setEnabled(True)
+            self.ili_file_browse_button.setEnabled(True)
+            self.ili_models_line_edit.setEnabled(False)
+            self.ili_models_line_edit.setText("")
+            self.ili_models_line_edit.setValidator(None)
+            self.ili_models_line_edit.setStyleSheet('QLineEdit {{ background-color: {} }}'.format('#fff'))
+            fileValidator = FileValidator(pattern='*.ili')
+            self.ili_file_line_edit.setValidator(fileValidator)
+            self.ili_file_line_edit.textChanged.connect(self.validators.validate_line_edits)
+            self.ili_file_line_edit.textChanged.emit(self.ili_file_line_edit.text())

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -76,10 +76,12 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.validators = Validators()
         nonEmptyValidator = NonEmptyStringValidator()
 
+        self.ili_models_line_edit.setValidator(nonEmptyValidator)
+        fileValidator = FileValidator(pattern='*.ili')
+        self.ili_file_line_edit.setValidator(fileValidator)
         self.pg_host_line_edit.setValidator(nonEmptyValidator)
         self.pg_database_line_edit.setValidator(nonEmptyValidator)
         self.pg_user_line_edit.setValidator(nonEmptyValidator)
-        self.ili_models_line_edit.setValidator(nonEmptyValidator)
 
         self.pg_host_line_edit.textChanged.connect(self.validators.validate_line_edits)
         self.pg_host_line_edit.textChanged.emit(self.pg_host_line_edit.text())
@@ -88,23 +90,30 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.pg_user_line_edit.textChanged.connect(self.validators.validate_line_edits)
         self.pg_user_line_edit.textChanged.emit(self.pg_user_line_edit.text())
         self.ili_models_line_edit.textChanged.connect(self.validators.validate_line_edits)
-        self.ili_models_line_edit.textChanged.emit(self.ili_file_line_edit.text())
+        self.ili_file_line_edit.textChanged.connect(self.validators.validate_line_edits)
+        self.model_radio_toggled(self.model_radio_button.isChecked())
         self.ilicache = IliCache(base_config)
         self.ilicache.models_changed.connect(self.update_models_completer)
         self.ilicache.new_message.connect(self.show_message)
         self.ilicache.refresh()
-        self.radio_button_1.toggled.connect(self.radio1_clicked)
-        self.radio_button_2.toggled.connect(self.radio2_clicked)
+        self.model_radio_button.toggled.connect(self.model_radio_toggled)
 
     def accepted(self):
         configuration = self.updated_configuration()
 
         if self.type_combo_box.currentData() == 'ili':
-            if not self.ili_file_line_edit.text() and not self.ili_models_line_edit.text():
-                self.txtStdout.setText(
-                    self.tr('Please set a valid INTERLIS file or model before creating the project.'))
-                self.ili_file_line_edit.setFocus()
-                return
+            if self.model_radio_button.isChecked():
+                if not configuration.ilimodels:
+                    self.txtStdout.setText(
+                        self.tr('Please set a valid model before creating the project.'))
+                    self.ili_models_line_edit.setFocus()
+                    return
+            else:
+                if not self.ili_file_line_edit.validator().validate(configuration.ilifile, 0)[0] == QValidator.Acceptable:
+                    self.txtStdout.setText(
+                        self.tr('Please set a valid INTERLIS file before creating the project.'))
+                    self.ili_file_line_edit.setFocus()
+                    return
         if not configuration.host:
             self.txtStdout.setText(self.tr('Please set a host before creating the project.'))
             self.pg_host_line_edit.setFocus()
@@ -206,17 +215,20 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         configuration.database = self.pg_database_line_edit.text().strip()
         configuration.schema = self.pg_schema_line_edit.text().strip().lower()
         configuration.password = self.pg_password_line_edit.text()
-        configuration.ilifile = self.ili_file_line_edit.text().strip()
-        configuration.ilimodels = self.ili_models_line_edit.text().strip()
+        if self.model_radio_button.isChecked():
+            configuration.base_configuration = self.base_configuration
+            configuration.ilimodels = self.ili_models_line_edit.text().strip()
+        else:
+            configuration.ilifile = self.ili_file_line_edit.text().strip()
+
         configuration.epsg = self.epsg
         configuration.inheritance = self.ili2pg_options.get_inheritance_type()
-        configuration.base_configuration = self.base_configuration
 
         return configuration
 
     def save_configuration(self, configuration):
         settings = QSettings()
-        settings.setValue('QgsProjectGenerator/ili2pg/ilifile', configuration.ilifile)
+        settings.setValue('QgsProjectGenerator/ili2pg/ilifile', self.ili_file_line_edit.text().strip())
         settings.setValue('QgsProjectGenerator/ili2pg/epsg', self.epsg)
         settings.setValue('QgsProjectGenerator/ili2pg/host', configuration.host)
         settings.setValue('QgsProjectGenerator/ili2pg/port', configuration.port)
@@ -224,6 +236,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         settings.setValue('QgsProjectGenerator/ili2pg/database', configuration.database)
         settings.setValue('QgsProjectGenerator/ili2pg/schema', configuration.schema)
         settings.setValue('QgsProjectGenerator/ili2pg/password', configuration.password)
+        settings.setValue('QgsProjectGenerator/ili2pg/modelenabled', self.model_radio_button.isChecked())
         settings.setValue('QgsProjectGenerator/importtype', self.type_combo_box.currentData())
 
     def restore_configuration(self):
@@ -238,10 +251,14 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.pg_database_line_edit.setText(settings.value('QgsProjectGenerator/ili2pg/database'))
         self.pg_schema_line_edit.setText(settings.value('QgsProjectGenerator/ili2pg/schema'))
         self.pg_password_line_edit.setText(settings.value('QgsProjectGenerator/ili2pg/password'))
+
         self.type_combo_box.setCurrentIndex(
             self.type_combo_box.findData(settings.value('QgsProjectGenerator/importtype', 'pg')))
         self.type_changed()
         self.crs_changed()
+
+        checked_radio = settings.value('QgsProjectGenerator/ili2pg/modelenabled', True, bool)
+        self.model_radio_button.setChecked(True) if checked_radio else self.interlis_file_radio_button.setChecked(True)
 
     def disable(self):
         self.pg_config.setEnabled(False)
@@ -297,28 +314,15 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         elif level == QgsMessageBar.CRITICAL:
             self.bar.pushMessage(message, QgsMessageBar.WARNING, 10)
 
-    def radio1_clicked(self, enabled):
-        if enabled:
-            self.ili_models_line_edit.setEnabled(True)
-            nonEmptyValidator = NonEmptyStringValidator()
-            self.ili_models_line_edit.setValidator(nonEmptyValidator)
-            self.ili_models_line_edit.textChanged.connect(self.validators.validate_line_edits)
-            self.ili_models_line_edit.textChanged.emit(self.ili_file_line_edit.text())
-            self.ili_file_line_edit.setEnabled(False)
-            self.ili_file_browse_button.setEnabled(False)
-            self.ili_file_line_edit.setText("")
-            self.ili_file_line_edit.setValidator(None)
-            self.ili_file_line_edit.setStyleSheet('QLineEdit {{ background-color: {} }}'.format('#fff'))
+    def model_radio_toggled(self, enabled):
+        self.ili_models_line_edit.setEnabled(enabled)
+        self.ili_file_line_edit.setEnabled(not enabled)
+        self.ili_file_browse_button.setEnabled(not enabled)
 
-    def radio2_clicked(self, enabled):
-        if enabled:
-            self.ili_file_line_edit.setEnabled(True)
-            self.ili_file_browse_button.setEnabled(True)
-            self.ili_models_line_edit.setEnabled(False)
-            self.ili_models_line_edit.setText("")
-            self.ili_models_line_edit.setValidator(None)
+        if enabled: # Using models line edit
+            self.ili_file_line_edit.setStyleSheet('QLineEdit {{ background-color: {} }}'.format('#fff'))
+            self.ili_models_line_edit.textChanged.emit(self.ili_models_line_edit.text())
+        else: # Using interlis file line edit
             self.ili_models_line_edit.setStyleSheet('QLineEdit {{ background-color: {} }}'.format('#fff'))
-            fileValidator = FileValidator(pattern='*.ili')
-            self.ili_file_line_edit.setValidator(fileValidator)
-            self.ili_file_line_edit.textChanged.connect(self.validators.validate_line_edits)
             self.ili_file_line_edit.textChanged.emit(self.ili_file_line_edit.text())
+

--- a/projectgenerator/ui/generate_project.ui
+++ b/projectgenerator/ui/generate_project.ui
@@ -135,28 +135,28 @@
           <string>Interlis</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_5">
-          <item row="4" column="2" colspan="2">
+          <item row="4" column="3" colspan="2">
            <widget class="QPushButton" name="ili2pg_options_button">
             <property name="text">
              <string>Advanced Options</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="1" column="1">
            <widget class="QLabel" name="label_7">
             <property name="text">
              <string>Model</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1" colspan="3">
+          <item row="3" column="2" colspan="3">
            <widget class="QgsProjectionSelectionWidget" name="crsSelector" native="true">
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="3" column="1">
            <widget class="QLabel" name="crs_label">
             <property name="toolTip">
              <string>Coordinate Reference System</string>
@@ -166,27 +166,31 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1" colspan="3">
-           <widget class="QLineEdit" name="ili_models_line_edit"/>
-          </item>
-          <item row="2" column="0">
+          <item row="2" column="1">
            <widget class="QLabel" name="label">
             <property name="text">
              <string>Interlis File</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="3">
+          <item row="2" column="4">
            <widget class="QToolButton" name="ili_file_browse_button">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="text">
              <string>...</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QLineEdit" name="ili_file_line_edit"/>
+          <item row="2" column="2" colspan="2">
+           <widget class="QLineEdit" name="ili_file_line_edit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
           </item>
-          <item row="4" column="1">
+          <item row="4" column="2">
            <spacer name="horizontalSpacer">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -198,6 +202,26 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item row="1" column="0">
+           <widget class="QRadioButton" name="radio_button_1">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2" colspan="3">
+           <widget class="QLineEdit" name="ili_models_line_edit"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QRadioButton" name="radio_button_2">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/projectgenerator/ui/generate_project.ui
+++ b/projectgenerator/ui/generate_project.ui
@@ -135,45 +135,7 @@
           <string>Interlis</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_5">
-          <item row="4" column="3" colspan="2">
-           <widget class="QPushButton" name="ili2pg_options_button">
-            <property name="text">
-             <string>Advanced Options</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Model</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2" colspan="3">
-           <widget class="QgsProjectionSelectionWidget" name="crsSelector" native="true">
-            <property name="focusPolicy">
-             <enum>Qt::StrongFocus</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLabel" name="crs_label">
-            <property name="toolTip">
-             <string>Coordinate Reference System</string>
-            </property>
-            <property name="text">
-             <string>CRS</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Interlis File</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="4">
+          <item row="2" column="3">
            <widget class="QToolButton" name="ili_file_browse_button">
             <property name="enabled">
              <bool>false</bool>
@@ -183,14 +145,28 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="2" colspan="2">
+          <item row="4" column="2" colspan="2">
+           <widget class="QPushButton" name="ili2pg_options_button">
+            <property name="text">
+             <string>Advanced Options</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="3">
+           <widget class="QgsProjectionSelectionWidget" name="crsSelector">
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="2">
            <widget class="QLineEdit" name="ili_file_line_edit">
             <property name="enabled">
              <bool>false</bool>
             </property>
            </widget>
           </item>
-          <item row="4" column="2">
+          <item row="4" column="1">
            <spacer name="horizontalSpacer">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -204,22 +180,35 @@
            </spacer>
           </item>
           <item row="1" column="0">
-           <widget class="QRadioButton" name="radio_button_1">
+           <widget class="QRadioButton" name="model_radio_button">
             <property name="text">
-             <string/>
+             <string>Model</string>
             </property>
             <property name="checked">
              <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="1" column="2" colspan="3">
+          <item row="1" column="1" colspan="3">
            <widget class="QLineEdit" name="ili_models_line_edit"/>
           </item>
           <item row="2" column="0">
-           <widget class="QRadioButton" name="radio_button_2">
+           <widget class="QRadioButton" name="interlis_file_radio_button">
             <property name="text">
-             <string/>
+             <string>Interlis File</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="crs_label">
+            <property name="toolTip">
+             <string>Coordinate Reference System</string>
+            </property>
+            <property name="text">
+             <string>CRS</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
             </property>
            </widget>
           </item>
@@ -274,7 +263,9 @@
  </customwidgets>
  <tabstops>
   <tabstop>type_combo_box</tabstop>
+  <tabstop>model_radio_button</tabstop>
   <tabstop>ili_models_line_edit</tabstop>
+  <tabstop>interlis_file_radio_button</tabstop>
   <tabstop>ili_file_line_edit</tabstop>
   <tabstop>ili_file_browse_button</tabstop>
   <tabstop>crsSelector</tabstop>
@@ -286,6 +277,7 @@
   <tabstop>pg_user_line_edit</tabstop>
   <tabstop>pg_password_line_edit</tabstop>
   <tabstop>txtStdout</tabstop>
+  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
Current status of models/ili-file selection in Generate GUI is a bit confusing. 

This PR aims to make it explicit what parameter you want to use as user: either use modeldir/model pair or an Interlis file. This allows us to validate input since those parameters are not optional anymore once users choose what parameter they prefer.