### PR TITLE
Add help button for generate - import - export - settings dialogs

### DIFF
--- a/projectgenerator/gui/export.py
+++ b/projectgenerator/gui/export.py
@@ -228,4 +228,4 @@ class ExportDialog(QDialog, DIALOG_UI):
         self.ili_models_line_edit.setCompleter(completer)
 
     def help_requested(self):
-        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/")
+        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/user-guide.html#export-an-interlis-transfer-file-xtf")

--- a/projectgenerator/gui/export.py
+++ b/projectgenerator/gui/export.py
@@ -18,7 +18,7 @@
  ***************************************************************************/
 """
 
-import os
+import os, webbrowser
 
 from projectgenerator.gui.options import OptionsDialog
 from projectgenerator.libili2pg.iliexporter import JavaNotFoundError
@@ -44,6 +44,8 @@ class ExportDialog(QDialog, DIALOG_UI):
         self.buttonBox.clear()
         self.buttonBox.addButton(QDialogButtonBox.Cancel)
         self.buttonBox.addButton(self.tr('Export'), QDialogButtonBox.AcceptRole)
+        self.buttonBox.addButton(QDialogButtonBox.Help)
+        self.buttonBox.helpRequested.connect(self.help_requested)
         self.xtf_file_browse_button.clicked.connect(
             make_save_file_selector(self.xtf_file_line_edit, title=self.tr('Save in XTF Transfer File'),
                                     file_filter=self.tr('XTF Transfer File (*.xtf)')))
@@ -224,3 +226,6 @@ class ExportDialog(QDialog, DIALOG_UI):
         completer = QCompleter(self.ilicache.model_names)
         completer.setCaseSensitivity(Qt.CaseInsensitive)
         self.ili_models_line_edit.setCompleter(completer)
+
+    def help_requested(self):
+        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/")

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -295,4 +295,4 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             self.bar.pushMessage(message, QgsMessageBar.WARNING, 10)
 
     def help_requested(self):
-        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/")
+        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/user-guide.html#generate-project")

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -18,7 +18,7 @@
  ***************************************************************************/
 """
 
-import os
+import os, webbrowser
 
 from psycopg2 import OperationalError
 
@@ -54,6 +54,8 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.ili_file_browse_button.clicked.connect(
             make_file_selector(self.ili_file_line_edit, title=self.tr('Open Interlis Model'),
                                file_filter=self.tr('Interlis Model File (*.ili)')))
+        self.buttonBox.addButton(QDialogButtonBox.Help)
+        self.buttonBox.helpRequested.connect(self.help_requested)
         self.crs = QgsCoordinateReferenceSystem()
         self.ili2pg_options = Ili2pgOptionsDialog()
         self.ili2pg_options_button.clicked.connect(self.ili2pg_options.open)
@@ -291,3 +293,6 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             self.bar.pushMessage(message, QgsMessageBar.INFO, 10)
         elif level == QgsMessageBar.CRITICAL:
             self.bar.pushMessage(message, QgsMessageBar.WARNING, 10)
+
+    def help_requested(self):
+        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/")

--- a/projectgenerator/gui/import_data.py
+++ b/projectgenerator/gui/import_data.py
@@ -231,4 +231,4 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.ili_models_line_edit.setCompleter(completer)
 
     def help_requested(self):
-        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/")
+        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/user-guide.html#import-an-interlis-transfer-file-xtf")

--- a/projectgenerator/gui/import_data.py
+++ b/projectgenerator/gui/import_data.py
@@ -18,7 +18,7 @@
  ***************************************************************************/
 """
 
-import os
+import os, webbrowser
 
 from projectgenerator.gui.options import OptionsDialog
 from projectgenerator.libili2pg.ilidataimporter import JavaNotFoundError
@@ -44,6 +44,8 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.buttonBox.clear()
         self.buttonBox.addButton(QDialogButtonBox.Cancel)
         self.buttonBox.addButton(self.tr('Import Data'), QDialogButtonBox.AcceptRole)
+        self.buttonBox.addButton(QDialogButtonBox.Help)
+        self.buttonBox.helpRequested.connect(self.help_requested)
         self.xtf_file_browse_button.clicked.connect(
             make_file_selector(self.xtf_file_line_edit, title=self.tr('Open XTF Transfer File'),
                                     file_filter=self.tr('XTF Transfer File (*.xtf)')))
@@ -227,3 +229,6 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         completer = QCompleter(self.ilicache.model_names)
         completer.setCaseSensitivity(Qt.CaseInsensitive)
         self.ili_models_line_edit.setCompleter(completer)
+
+    def help_requested(self):
+        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/")

--- a/projectgenerator/gui/options.py
+++ b/projectgenerator/gui/options.py
@@ -17,6 +17,7 @@
  *                                                                         *
  ***************************************************************************/
 """
+import webbrowser
 
 from projectgenerator.utils import get_ui_class
 from projectgenerator.utils import qt_utils
@@ -43,6 +44,7 @@ class OptionsDialog(QDialog, DIALOG_UI):
         self.ili2db_logfile_search_button.clicked.connect(qt_utils.make_file_selector(self.ili2db_logfile_path, self.tr('Select java application.'), self.tr('java (*)')))
         self.ili2db_enable_debugging.setChecked(self.configuration.debugging_enabled)
         self.buttonBox.accepted.connect(self.accepted)
+        self.buttonBox.helpRequested.connect(self.help_requested)
         self.custom_models_dir_button.clicked.connect(self.show_custom_model_dir)
 
     def accepted(self):
@@ -55,3 +57,6 @@ class OptionsDialog(QDialog, DIALOG_UI):
     def show_custom_model_dir(self):
         dlg = CustomModelDirDialog(self.custom_model_directories_line_edit.text(), self)
         dlg.exec_()
+
+    def help_requested(self):
+        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/")

--- a/projectgenerator/gui/options.py
+++ b/projectgenerator/gui/options.py
@@ -59,4 +59,4 @@ class OptionsDialog(QDialog, DIALOG_UI):
         dlg.exec_()
 
     def help_requested(self):
-        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/")
+        webbrowser.open("https://opengisch.github.io/projectgenerator/docs/user-guide.html#plugin-configuration")

--- a/projectgenerator/ui/export.ui
+++ b/projectgenerator/ui/export.ui
@@ -196,7 +196,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/projectgenerator/ui/generate_project.ui
+++ b/projectgenerator/ui/generate_project.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Import Interlis</string>
+   <string>Generate Project</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="1" column="0" colspan="2">
@@ -220,7 +220,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/projectgenerator/ui/import_data.ui
+++ b/projectgenerator/ui/import_data.ui
@@ -203,7 +203,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/projectgenerator/ui/options.ui
+++ b/projectgenerator/ui/options.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>403</width>
-    <height>300</height>
+    <height>305</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -165,7 +165,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Add help button for the following dialogs boxes:

- Generate
- Import
- Export
- Settings 

This button redirects the user to the web page projectgenerator-docs, in the future we will be able to specify the index in each dialog according to the improvement of the documentation. 

Also change the title of generate.ui which was "Import Interlis" to "Generate Project"