### PR TITLE
Improve handling of ili files and models in Generate dialog

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -75,10 +75,13 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
 
         self.validators = Validators()
         nonEmptyValidator = NonEmptyStringValidator()
+        fileValidator = FileValidator(pattern='*.ili')
 
+        self.ili_models_line_edit.setValidator(nonEmptyValidator)
         self.pg_host_line_edit.setValidator(nonEmptyValidator)
         self.pg_database_line_edit.setValidator(nonEmptyValidator)
         self.pg_user_line_edit.setValidator(nonEmptyValidator)
+        self.ili_file_line_edit.setValidator(fileValidator)
 
         self.pg_host_line_edit.textChanged.connect(self.validators.validate_line_edits)
         self.pg_host_line_edit.textChanged.emit(self.pg_host_line_edit.text())
@@ -86,6 +89,8 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.pg_database_line_edit.textChanged.emit(self.pg_database_line_edit.text())
         self.pg_user_line_edit.textChanged.connect(self.validators.validate_line_edits)
         self.pg_user_line_edit.textChanged.emit(self.pg_user_line_edit.text())
+        self.ili_models_line_edit.textChanged.connect(self.validators.validate_line_edits)
+        self.ili_file_line_edit.textChanged.connect(self.validators.validate_line_edits)
         self.ilicache = IliCache(base_config)
         self.ilicache.models_changed.connect(self.update_models_completer)
         self.ilicache.new_message.connect(self.show_message)

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -75,7 +75,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
 
         self.validators = Validators()
         nonEmptyValidator = NonEmptyStringValidator()
-        fileValidator = FileValidator(pattern='*.ili')
+        fileValidator = FileValidator(pattern='*.ili', allow_empty=True)
 
         self.ili_models_line_edit.setValidator(nonEmptyValidator)
         self.pg_host_line_edit.setValidator(nonEmptyValidator)

--- a/projectgenerator/libili2pg/iliimporter.py
+++ b/projectgenerator/libili2pg/iliimporter.py
@@ -125,13 +125,15 @@ class Importer(QObject):
         if self.configuration.epsg != 21781:
             args += ["--defaultSrsCode", "{}".format(self.configuration.epsg)]
 
-        args += self.configuration.base_configuration.to_ili2db_args()
-
         if self.configuration.ilimodels:
             args += ['--models', self.configuration.ilimodels]
 
         if self.configuration.ilifile:
+            # Valid ili file, don't pass --modelDir (it can cause ili2db errors)
+            args += self.configuration.base_configuration.to_ili2db_args(export_modeldir=False)
             args += [self.configuration.ilifile]
+        else:
+            args += self.configuration.base_configuration.to_ili2db_args()
 
         if self.configuration.base_configuration.java_path:
             # A java path is configured: respect it no mather what

--- a/projectgenerator/ui/generate_project.ui
+++ b/projectgenerator/ui/generate_project.ui
@@ -199,7 +199,11 @@
            </widget>
           </item>
           <item row="0" column="1" colspan="2">
-           <widget class="QLineEdit" name="ili_file_line_edit"/>
+           <widget class="QLineEdit" name="ili_file_line_edit">
+            <property name="placeholderText">
+             <string>[Optional]</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -252,6 +256,8 @@
  </customwidgets>
  <tabstops>
   <tabstop>type_combo_box</tabstop>
+  <tabstop>ili_file_line_edit</tabstop>
+  <tabstop>ili_file_browse_button</tabstop>
   <tabstop>ili_models_line_edit</tabstop>
   <tabstop>crsSelector</tabstop>
   <tabstop>ili2pg_options_button</tabstop>

--- a/projectgenerator/ui/generate_project.ui
+++ b/projectgenerator/ui/generate_project.ui
@@ -142,18 +142,13 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Model</string>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="1" colspan="3">
            <widget class="QgsProjectionSelectionWidget" name="crsSelector" native="true">
             <property name="focusPolicy">
              <enum>Qt::StrongFocus</enum>
             </property>
+            <zorder>label_7</zorder>
+            <zorder>ili_models_line_edit</zorder>
            </widget>
           </item>
           <item row="3" column="0">
@@ -165,26 +160,6 @@
              <string>CRS</string>
             </property>
            </widget>
-          </item>
-          <item row="1" column="1" colspan="3">
-           <widget class="QLineEdit" name="ili_models_line_edit"/>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Interlis File</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QToolButton" name="ili_file_browse_button">
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QLineEdit" name="ili_file_line_edit"/>
           </item>
           <item row="4" column="1">
            <spacer name="horizontalSpacer">
@@ -198,6 +173,33 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Model</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" colspan="3">
+           <widget class="QLineEdit" name="ili_models_line_edit"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Interlis File</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QToolButton" name="ili_file_browse_button">
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QLineEdit" name="ili_file_line_edit"/>
           </item>
          </layout>
         </widget>
@@ -251,8 +253,6 @@
  <tabstops>
   <tabstop>type_combo_box</tabstop>
   <tabstop>ili_models_line_edit</tabstop>
-  <tabstop>ili_file_line_edit</tabstop>
-  <tabstop>ili_file_browse_button</tabstop>
   <tabstop>crsSelector</tabstop>
   <tabstop>ili2pg_options_button</tabstop>
   <tabstop>pg_host_line_edit</tabstop>

--- a/projectgenerator/utils/qt_utils.py
+++ b/projectgenerator/utils/qt_utils.py
@@ -131,13 +131,16 @@ class Validators(QObject):
         """
         senderObj = self.sender()
         validator = senderObj.validator()
-        state = validator.validate(senderObj.text().strip(), 0)[0]
-        if state == QValidator.Acceptable:
+        if validator is None:
             color = '#fff'  # White
-        elif state == QValidator.Intermediate:
-            color = '#ffd356'  # Light orange
         else:
-            color = '#f6989d'  # Red
+            state = validator.validate(senderObj.text().strip(), 0)[0]
+            if state == QValidator.Acceptable:
+                color = '#fff'  # White
+            elif state == QValidator.Intermediate:
+                color = '#ffd356'  # Light orange
+            else:
+                color = '#f6989d'  # Red
         senderObj.setStyleSheet('QLineEdit {{ background-color: {} }}'.format(color))
 
 

--- a/projectgenerator/utils/qt_utils.py
+++ b/projectgenerator/utils/qt_utils.py
@@ -142,7 +142,7 @@ class Validators(QObject):
 
 
 class FileValidator(QValidator):
-    def __init__(self, pattern='*', is_executable=False, parent=None, allow_empty=False, allow_non_existing=False):
+    def __init__(self, pattern='*', is_executable=False, parent=None, allow_empty=True, allow_non_existing=False):
         QValidator.__init__(self, parent)
         self.pattern = pattern
         self.is_executable = is_executable

--- a/projectgenerator/utils/qt_utils.py
+++ b/projectgenerator/utils/qt_utils.py
@@ -142,7 +142,7 @@ class Validators(QObject):
 
 
 class FileValidator(QValidator):
-    def __init__(self, pattern='*', is_executable=False, parent=None, allow_empty=True, allow_non_existing=False):
+    def __init__(self, pattern='*', is_executable=False, parent=None, allow_empty=False, allow_non_existing=False):
         QValidator.__init__(self, parent)
         self.pattern = pattern
         self.is_executable = is_executable


### PR DESCRIPTION
New proposal to deal with ili files and models when Generating Projects in Interlis mode.

 + ili file line edit goes before models line edit, because the former's value may impact the latter.
 + ili file line edit is valid if no value is given ("[Optional]" placeholder introduced) or an existing path is given.
 + If a valid and existing ili file is given:
   + Models line edit gets a `None` validator (since it becomes optional).
   + Completer changes to show only models from the given ili file.
   + --modelDir is not passed as argument to ili2db (parents of a given model from the ili file are searched for in modelDir and if not found there, ili2db throws errors, so it's safer not to pass it).
   + ili file is passed as argument to ili2db.
 + If there is no value for ili file:
   + Models line edit gets `NonEmptyString` validator (since it becomes mandatory).
   + Completer changes to show models from modelDir.
   + Both --modelDir and --models are passed as arguments to ili2db.