### PR TITLE
Ensure a best and not arbitrary time.

### DIFF
--- a/.docker/run-docker-tests.sh
+++ b/.docker/run-docker-tests.sh
@@ -17,7 +17,13 @@
 #***************************************************************************
 
 set -e
-sleep 10 # Wait for postgres container to become available
+# rationale: Wait for postgres container to become available
+while ! PGPASSWORD='docker' psql -h postgres -U docker -p 5432 -l &> /dev/null
+do
+  echo "Wait a moment while loading the database."
+  sleep 2
+done
+
 pushd /usr/src
 xvfb-run nose2-3
 popd

--- a/projectgenerator/tests/README.md
+++ b/projectgenerator/tests/README.md
@@ -7,5 +7,6 @@ with a database, so your own postgres installation is not affected at all.
 To run the tests, go to the main directory of the project and do
 
 ```sh
-docker-compose -f .docker/docker-compose.travis.yml run qgis /usr/src/.docker/run-docker-tests.sh
+export TRAVIS_BUILD_DIR=$PWD # only for local execution
+docker-compose -f .docker/docker-compose.travis.yml run --rm qgis /usr/src/.docker/run-docker-tests.sh
 ```


### PR DESCRIPTION
A way to wait for postgres container to become available.
This is because 10 seconds is not sufficient to up postgres in all computers.