### PR TITLE
Make Project Generator useful from other plugins

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -59,7 +59,8 @@ from qgis.PyQt.QtCore import (
 )
 from qgis.core import (
     QgsProject,
-    QgsCoordinateReferenceSystem
+    QgsCoordinateReferenceSystem,
+    Qgis
 )
 from qgis.gui import QgsMessageBar
 from ..utils import get_ui_class
@@ -475,10 +476,10 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.multiple_models_dialog.models_line_edit.setCompleter(completer)
 
     def show_message(self, level, message):
-        if level == QgsMessageBar.WARNING:
-            self.bar.pushMessage(message, QgsMessageBar.INFO, 10)
-        elif level == QgsMessageBar.CRITICAL:
-            self.bar.pushMessage(message, QgsMessageBar.WARNING, 10)
+        if level == Qgis.Warning:
+            self.bar.pushMessage(message, Qgis.Info, 10)
+        elif level == Qgis.Critical:
+            self.bar.pushMessage(message, Qgis.Warning, 10)
 
     def fill_models_line_edit(self):
         self.ili_models_line_edit.setText(

--- a/projectgenerator/libili2db/ilicache.py
+++ b/projectgenerator/libili2db/ilicache.py
@@ -27,8 +27,7 @@ import re
 
 from projectgenerator.utils.qt_utils import download_file, NetworkError
 from PyQt5.QtCore import QObject, pyqtSignal
-from qgis.core import QgsMessageLog
-from qgis.gui import QgsMessageBar
+from qgis.core import QgsMessageLog, Qgis
 
 
 class IliCache(QObject):
@@ -169,10 +168,10 @@ class IliCache(QObject):
         except UnicodeDecodeError:
             try:
                 fileModels = self.parse_ili_file(ilifile, "latin1")
-                self.new_message.emit(QgsMessageBar.WARNING,
+                self.new_message.emit(Qgis.Warning,
                                       self.tr('Even though the ili file `{}` could be read, it is not in UTF-8. Please encode your ili models in UTF-8.'.format(os.path.basename(ilifile))))
             except UnicodeDecodeError:
-                self.new_message.emit(QgsMessageBar.CRITICAL,
+                self.new_message.emit(Qgis.Critical,
                                       self.tr('Could not parse ili file `{}` with UTF-8 nor Latin-1 encodings. Please encode your ili models in UTF-8.'.format(os.path.basename(ilifile))))
                 QgsMessageLog.logMessage(self.tr('Could not parse ili file `{ilifile}`. We suggest you to encode it in UTF-8. ({exception})'.format(
                     ilifile=ilifile, exception=str(e))), self.tr('Projectgenerator'))

--- a/projectgenerator/libqgsprojectgen/dataobjects/legend.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/legend.py
@@ -57,12 +57,14 @@ class LegendGroup(object):
 
         for item in self.items:
             if isinstance(item, LegendGroup):
-                subgroup = group.addGroup(item.name)
-                subgroup.setExpanded(item.expanded)
+                subgroup = group.findGroup(item.name)
+                if subgroup is None:
+                    subgroup = group.addGroup(item.name)
+                    subgroup.setExpanded(item.expanded)
                 item.create(qgis_project, subgroup)
             else:
                 layer = item.layer
-                group.addLayer(layer)
+                group.insertLayer(0, layer)
 
     def is_empty(self):
         return not bool(self.items)

--- a/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
@@ -81,7 +81,7 @@ class DBConnector:
         '''
         return {}
 
-    def get_relations_info(self):
+    def get_relations_info(self, filter_layer_list=[]):
         '''
         Info about relations found in a database (or database schema).
 

--- a/projectgenerator/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -146,8 +146,8 @@ class GPKGConnector(DBConnector):
 
         return constraint_mapping
 
-    def get_relations_info(self):
-        # We need to get the PK for each table, so firts get tables_info
+    def get_relations_info(self, filter_layer_list=[]):
+        # We need to get the PK for each table, so first get tables_info
         # and then build something more searchable
         tables_info_dict = dict()
         for table_info in self._tables_info:

--- a/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
@@ -154,23 +154,26 @@ class PGConnector(DBConnector):
 
         return constraint_mapping
 
-    def get_relations_info(self):
+    def get_relations_info(self, filter_layer_list=[]):
         cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
         schema_where1 = "AND KCU1.CONSTRAINT_SCHEMA = '{}'".format(
             self.schema) if self.schema else ''
         schema_where2 = "AND KCU2.CONSTRAINT_SCHEMA = '{}'".format(
             self.schema) if self.schema else ''
+        filter_layer_where = ""
+        if filter_layer_list:
+            filter_layer_where = "AND KCU1.TABLE_NAME IN ('{}')".format("','".join(filter_layer_list))
 
         cur.execute("""SELECT RC.CONSTRAINT_NAME, KCU1.TABLE_NAME AS referencing_table, KCU1.COLUMN_NAME AS referencing_column, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME AS referenced_table, KCU2.COLUMN_NAME AS referenced_column, KCU1.ORDINAL_POSITION
                         FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC
                         INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU1
-                        ON KCU1.CONSTRAINT_CATALOG = RC.CONSTRAINT_CATALOG AND KCU1.CONSTRAINT_SCHEMA = RC.CONSTRAINT_SCHEMA AND KCU1.CONSTRAINT_NAME = RC.CONSTRAINT_NAME {schema_where1}
+                        ON KCU1.CONSTRAINT_CATALOG = RC.CONSTRAINT_CATALOG AND KCU1.CONSTRAINT_SCHEMA = RC.CONSTRAINT_SCHEMA AND KCU1.CONSTRAINT_NAME = RC.CONSTRAINT_NAME {schema_where1} {filter_layer_where}
                         INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU2
                           ON KCU2.CONSTRAINT_CATALOG = RC.UNIQUE_CONSTRAINT_CATALOG AND KCU2.CONSTRAINT_SCHEMA = RC.UNIQUE_CONSTRAINT_SCHEMA AND KCU2.CONSTRAINT_NAME = RC.UNIQUE_CONSTRAINT_NAME
                           AND KCU2.ORDINAL_POSITION = KCU1.ORDINAL_POSITION {schema_where2}
                         GROUP BY RC.CONSTRAINT_NAME, KCU1.TABLE_NAME, KCU1.COLUMN_NAME, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME, KCU2.COLUMN_NAME, KCU1.ORDINAL_POSITION
                         ORDER BY KCU1.ORDINAL_POSITION
-                        """.format(schema_where1=schema_where1, schema_where2=schema_where2))
+                        """.format(schema_where1=schema_where1, schema_where2=schema_where2, filter_layer_where=filter_layer_where))
         return cur
 
     def get_domainili_domaindb_mapping(self, domains):

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -43,7 +43,7 @@ class Generator:
         elif self.tool_name == 'ili2gpkg':
             self._db_connector = gpkg_connector.GPKGConnector(uri, None)
 
-    def layers(self):
+    def layers(self, filter_layer_list=[]):
         tables_info = self._get_tables_info()
         layers = list()
 
@@ -57,6 +57,9 @@ class Generator:
                 continue
 
             if record['tablename'] in IGNORED_TABLES:
+                continue
+
+            if filter_layer_list and record['tablename'] not in filter_layer_list:
                 continue
 
             if self.tool_name == 'ili2pg':
@@ -160,8 +163,8 @@ class Generator:
 
         return layers
 
-    def relations(self, layers):
-        relations_info = self._get_relations_info()
+    def relations(self, layers, filter_layer_list=[]):
+        relations_info = self._get_relations_info() # Make this aware of filter_layer_list
         mapped_layers = {layer.name: layer for layer in layers}
         relations = list()
 

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -164,7 +164,7 @@ class Generator:
         return layers
 
     def relations(self, layers, filter_layer_list=[]):
-        relations_info = self._get_relations_info() # Make this aware of filter_layer_list
+        relations_info = self._get_relations_info(filter_layer_list)
         mapped_layers = {layer.name: layer for layer in layers}
         relations = list()
 
@@ -243,8 +243,8 @@ class Generator:
     def _get_constraints_info(self, table_name):
         return self._db_connector.get_constraints_info(table_name)
 
-    def _get_relations_info(self):
-        return self._db_connector.get_relations_info()
+    def _get_relations_info(self, filter_layer_list=[]):
+        return self._db_connector.get_relations_info(filter_layer_list)
 
 
 class DomainRelationGenerator:

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -217,11 +217,11 @@ class Generator:
                 else:
                     tables.append(layer)
 
-        for l in point_layers:
+        for l in polygon_layers:
             legend.append(l)
         for l in line_layers:
             legend.append(l)
-        for l in polygon_layers:
+        for l in point_layers:
             legend.append(l)
 
         if not tables.is_empty():

--- a/projectgenerator/qgs_project_generator.py
+++ b/projectgenerator/qgs_project_generator.py
@@ -24,6 +24,10 @@ import webbrowser
 from projectgenerator.gui.generate_project import GenerateProjectDialog
 from projectgenerator.gui.export import ExportDialog
 from projectgenerator.gui.import_data import ImportDataDialog
+from projectgenerator.libqgsprojectgen.dataobjects.project import Project
+from projectgenerator.libqgsprojectgen.generator.generator import Generator
+
+from qgis.core import QgsProject
 from qgis.PyQt.QtWidgets import QAction, QMenu, QMessageBox
 from qgis.PyQt.QtCore import QObject, QTranslator, QSettings, QLocale, QCoreApplication, Qt
 
@@ -156,3 +160,15 @@ class QgsProjectGeneratorPlugin(QObject):
         <a href="https://www.proadmintierra.info/">Agencia de Implementación (BSF-Swissphoto AG / INCIGE S.A.S.)</a>.</p></p>"""))
         self.msg.setStandardButtons(QMessageBox.Close)
         msg_box = self.msg.exec_()
+
+    def get_generator(self):
+        return Generator
+
+    def create_project(self, layers, relations, legend):
+        project = Project()
+        project.layers = layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)


### PR DESCRIPTION
Other QGIS plugins (e.g., our [Asistente LADM_COL](https://github.com/AgenciaImplementacion/Asistente-LADM_COL)) may need to access Project Generator functionality, such as loading layers with forms, widgets and relations configured from a PostgreSQL schema. 

This PR exposes the `Generator` object (to build Project Generator data objects on demand) as well as a call to `Project.create_project()` to build the QGIS project. Additionally, this PR optimizes `DBConnector.get_relations_info()` so that it can use a list of layers and filter out information that is not required from the DB.

For reference, the Asistente LADM_COL uses such exposed methods [in this way](https://github.com/AgenciaImplementacion/Asistente-LADM_COL/blob/master/asistente_ladm_col/utils/project_generator_utils.py).

Fix #137