### PR TITLE
Order layers by geometry, even for subsequent calls to project.create()

### DIFF
--- a/projectgenerator/libqgsprojectgen/dataobjects/legend.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/legend.py
@@ -20,6 +20,9 @@
 
 from qgis.core import QgsProject
 
+from projectgenerator.utils.qgis_utils import get_suggested_index_for_layer
+
+
 
 class LegendGroup(object):
 
@@ -64,7 +67,8 @@ class LegendGroup(object):
                 item.create(qgis_project, subgroup)
             else:
                 layer = item.layer
-                group.insertLayer(0, layer)
+                index = get_suggested_index_for_layer(layer) if layer.isSpatial() else 0
+                group.insertLayer(index, layer)
 
     def is_empty(self):
         return not bool(self.items)

--- a/projectgenerator/libqgsprojectgen/dataobjects/legend.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/legend.py
@@ -67,7 +67,7 @@ class LegendGroup(object):
                 item.create(qgis_project, subgroup)
             else:
                 layer = item.layer
-                index = get_suggested_index_for_layer(layer) if layer.isSpatial() else 0
+                index = get_suggested_index_for_layer(layer, group) if layer.isSpatial() else 0
                 group.insertLayer(index, layer)
 
     def is_empty(self):

--- a/projectgenerator/utils/qgis_utils.py
+++ b/projectgenerator/utils/qgis_utils.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+    begin                :    05/03/18
+    git sha              :    :%H$
+    copyright            :    (C) 2018 by Germán Carrillo (BSF-Swissphoto)
+    email                :    gcarrillo@linuxmail.org
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from qgis.core import QgsLayerTreeNode, QgsProject, QgsWkbTypes
+
+layer_order = [QgsWkbTypes.PointGeometry,
+               QgsWkbTypes.LineGeometry,
+               QgsWkbTypes.PolygonGeometry,
+               QgsWkbTypes.UnknownGeometry]
+
+def get_first_index_for_geometry_type(geometry_type, group=QgsProject.instance().layerTreeRoot()):
+    tree_nodes = group.children()
+
+    for current, tree_node in enumerate(tree_nodes):
+        if tree_node.nodeType() == QgsLayerTreeNode.NodeGroup and geometry_type != QgsWkbTypes.UnknownGeometry:
+            return None
+        elif tree_node.nodeType() == QgsLayerTreeNode.NodeGroup and geometry_type == QgsWkbTypes.UnknownGeometry:
+            return current
+
+        layer = tree_node.layer()
+        if layer.geometryType() == geometry_type:
+            return current
+
+    return None
+
+def get_suggested_index_for_layer(layer):
+    for geometry_type in layer_order[layer_order.index(layer.geometryType()):]: # slice from current until last
+        index = get_first_index_for_geometry_type(geometry_type)
+        if index is not None:
+            break
+
+    return -1 if index is None else index # Send it to the last position in layer tree

--- a/projectgenerator/utils/qgis_utils.py
+++ b/projectgenerator/utils/qgis_utils.py
@@ -17,14 +17,14 @@
  ***************************************************************************/
 """
 
-from qgis.core import QgsLayerTreeNode, QgsProject, QgsWkbTypes
+from qgis.core import QgsLayerTreeNode, QgsWkbTypes
 
 layer_order = [QgsWkbTypes.PointGeometry,
                QgsWkbTypes.LineGeometry,
                QgsWkbTypes.PolygonGeometry,
                QgsWkbTypes.UnknownGeometry]
 
-def get_first_index_for_geometry_type(geometry_type, group=QgsProject.instance().layerTreeRoot()):
+def get_first_index_for_geometry_type(geometry_type, group):
     """
     Finds the first index (from top to botton) in the layer tree where a
     specific layer type is found. This function works only for the given group.
@@ -43,7 +43,7 @@ def get_first_index_for_geometry_type(geometry_type, group=QgsProject.instance()
 
     return None
 
-def get_suggested_index_for_layer(layer):
+def get_suggested_index_for_layer(layer, group):
     """
     Returns the index where a layer can be inserted, taking other layer types
     into account. For instance, if a line layer is given, this function will
@@ -52,7 +52,7 @@ def get_suggested_index_for_layer(layer):
     groups. Always following the order given in the global layer_order variable.
     """
     for geometry_type in layer_order[layer_order.index(layer.geometryType()):]: # slice from current until last
-        index = get_first_index_for_geometry_type(geometry_type)
+        index = get_first_index_for_geometry_type(geometry_type, group)
         if index is not None:
             break
 

--- a/projectgenerator/utils/qgis_utils.py
+++ b/projectgenerator/utils/qgis_utils.py
@@ -25,6 +25,10 @@ layer_order = [QgsWkbTypes.PointGeometry,
                QgsWkbTypes.UnknownGeometry]
 
 def get_first_index_for_geometry_type(geometry_type, group=QgsProject.instance().layerTreeRoot()):
+    """
+    Finds the first index (from top to botton) in the layer tree where a
+    specific layer type is found. This function works only for the given group.
+    """
     tree_nodes = group.children()
 
     for current, tree_node in enumerate(tree_nodes):
@@ -40,6 +44,13 @@ def get_first_index_for_geometry_type(geometry_type, group=QgsProject.instance()
     return None
 
 def get_suggested_index_for_layer(layer):
+    """
+    Returns the index where a layer can be inserted, taking other layer types
+    into account. For instance, if a line layer is given, this function will
+    return the index of the first line layer in the layer tree, and if there are
+    no line layers in it, it will continue with the first index of polygons or
+    groups. Always following the order given in the global layer_order variable.
+    """
     for geometry_type in layer_order[layer_order.index(layer.geometryType()):]: # slice from current until last
         index = get_first_index_for_geometry_type(geometry_type)
         if index is not None:


### PR DESCRIPTION
New layers will be added to a proper place in the layer tree, depending on its geometry type. 
Geometry layers are always loaded at the top of the layer tree, i.e., above groups (like `tables` and `domains`).

@m-kuhn I think we could add these methods in QGIS as well (taking rasters into account), as it may be a commonly desired behaviour.