### PR TITLE
Add the model name for each table in tables_info (for both GPKG and PG)

### DIFF
--- a/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
@@ -51,6 +51,7 @@ class DBConnector:
                 type  (Geometry Type)
                 is_domain
                 table_alias
+                model
         '''
         return []
 

--- a/projectgenerator/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -55,7 +55,7 @@ class GPKGConnector(DBConnector):
     def _get_tables_info(self):
         cursor = self.conn.cursor()
         cursor.execute("""
-            SELECT NULL AS schemaname, s.name AS tablename, NULL AS primary_key, g.column_name AS geometry_column, g.srs_id AS srid, g.geometry_type_name AS type, p.setting AS is_domain, alias.setting AS table_alias
+            SELECT NULL AS schemaname, s.name AS tablename, NULL AS primary_key, g.column_name AS geometry_column, g.srs_id AS srid, g.geometry_type_name AS type, p.setting AS is_domain, alias.setting AS table_alias, substr(c.iliname, 0, instr(c.iliname, '.')) AS model
             FROM sqlite_master s
             LEFT JOIN gpkg_geometry_columns g
                ON g.table_name = s.name
@@ -65,6 +65,8 @@ class GPKGConnector(DBConnector):
             LEFT JOIN t_ili2db_table_prop alias
                ON alias.tablename = s.name
                   AND alias.tag = 'ch.ehi.ili2db.dispName'
+            LEFT JOIN t_ili2db_classname c
+               ON s.name == c.sqlname
             WHERE s.type='table';
                        """)
         records = cursor.fetchall()

--- a/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
@@ -109,8 +109,9 @@ class PGConnector(DBConnector):
                       AND g.f_table_name = tbls.tablename
                     WHERE i.indisprimary {schema_where}
         """.format(is_domain_field=is_domain_field, table_alias=table_alias,
-                   domain_left_join=domain_left_join, alias_left_join=alias_left_join,
-                   model_where=model_where, schema_where=schema_where))
+                   model_name=model_name, domain_left_join=domain_left_join,
+                   alias_left_join=alias_left_join, model_where=model_where,
+                   schema_where=schema_where))
 
         return cur
 

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -44,7 +44,7 @@ class Generator:
             self._db_connector = gpkg_connector.GPKGConnector(uri, None)
 
     def layers(self, filter_layer_list=[]):
-        tables_info = self._get_tables_info()
+        tables_info = self.get_tables_info()
         layers = list()
 
         for record in tables_info:
@@ -101,8 +101,8 @@ class Generator:
                           is_domain)
 
             # Configure fields for current table
-            fields_info = self._get_fields_info(record['tablename'])
-            constraints_info = self._get_constraints_info(record['tablename'])
+            fields_info = self.get_fields_info(record['tablename'])
+            constraints_info = self.get_constraints_info(record['tablename'])
             re_iliname = re.compile('^@iliname (.*)$')
 
             for fielddef in fields_info:
@@ -164,7 +164,7 @@ class Generator:
         return layers
 
     def relations(self, layers, filter_layer_list=[]):
-        relations_info = self._get_relations_info(filter_layer_list)
+        relations_info = self.get_relations_info(filter_layer_list)
         layer_map = dict()
         for layer in layers:
             if layer.name not in layer_map.keys():
@@ -234,19 +234,37 @@ class Generator:
 
         return legend
 
-    def _metadata_exists(self):
+    def metadata_exists(self):
         return self._db_connector.metadata_exists()
 
-    def _get_tables_info(self):
+    def get_tables_info(self):
         return self._db_connector.get_tables_info()
 
-    def _get_fields_info(self, table_name):
+    def get_tables_info_without_ignored_tables(self):
+        tables_info = self.get_tables_info()
+        new_tables_info = []
+        for record in tables_info:
+            if self.schema:
+                if record['schemaname'] != self.schema:
+                    continue
+            elif record['schemaname'] in IGNORED_SCHEMAS:
+                continue
+
+            if record['tablename'] in IGNORED_TABLES:
+                continue
+
+            new_tables_info.append(record)
+
+        return new_tables_info
+
+
+    def get_fields_info(self, table_name):
         return self._db_connector.get_fields_info(table_name)
 
-    def _get_constraints_info(self, table_name):
+    def get_constraints_info(self, table_name):
         return self._db_connector.get_constraints_info(table_name)
 
-    def _get_relations_info(self, filter_layer_list=[]):
+    def get_relations_info(self, filter_layer_list=[]):
         return self._db_connector.get_relations_info(filter_layer_list)
 
 

--- a/projectgenerator/utils/qgis_utils.py
+++ b/projectgenerator/utils/qgis_utils.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+    begin                :    05/03/18
+    git sha              :    :%H$
+    copyright            :    (C) 2018 by Germán Carrillo (BSF-Swissphoto)
+    email                :    gcarrillo@linuxmail.org
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from qgis.core import QgsLayerTreeNode, QgsProject, QgsWkbTypes
+
+layer_order = [QgsWkbTypes.PointGeometry,
+               QgsWkbTypes.LineGeometry,
+               QgsWkbTypes.PolygonGeometry,
+               QgsWkbTypes.UnknownGeometry]
+
+def get_first_index_for_geometry_type(geometry_type, group=QgsProject.instance().layerTreeRoot()):
+    tree_nodes = group.children()
+
+    for current, tree_node in enumerate(tree_nodes):
+        if tree_node.nodeType() == QgsLayerTreeNode.NodeGroup and geometry_type != QgsWkbTypes.UnknownGeometry:
+            return None
+        elif tree_node.nodeType() == QgsLayerTreeNode.NodeGroup and geometry_type == QgsWkbTypes.UnknownGeometry:
+            return current
+
+        layer = tree_node.layer()
+        if layer.geometryType() == geometry_type:
+            return current
+
+    return None
+
+def get_suggested_index_for_layer(layer):
+    for geometry_type in layer_order[layer_order.index(layer.geometryType()):]: # slice from current until last
+        index = get_first_index_for_geometry_type(geometry_type)
+        if index is not None:
+            break
+
+    return -1 if index is None else index # Send it to the last position in layer tree


### PR DESCRIPTION
We'd like to use the model from where each table comes in a custom "Load Layers" dialog of our Asistente LADM_COL plugin. 

Since we can use several models in an ilid2b schema import operation, having the model in the table info from Project Generator will help us to organize available layers in a hierarchical tree.