### PR TITLE
In PostgreSQL/PostGIS, avoid estimatedmetadata=true when setting layer URI

### DIFF
--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -65,7 +65,7 @@ class Generator:
             if self.tool_name == 'ili2pg':
                 provider = 'postgres'
                 if record['geometry_column']:
-                    data_source_uri = '{uri} key={primary_key} estimatedmetadata=true srid={srid} type={type} table="{schema}"."{table}" ({geometry_column})'.format(
+                    data_source_uri = '{uri} key={primary_key} srid={srid} type={type} table="{schema}"."{table}" ({geometry_column})'.format(
                         uri=self.uri,
                         primary_key=record['primary_key'],
                         srid=record['srid'],


### PR DESCRIPTION
Just faced an issue with a `layer.featureCount()` returning 0 when the DB actually had features, which made one of our tools run wrongly.

To prevent that scenario, this PR avoids the `estimatedmetadata=true` parameter in layer URI.