### PR TITLE
Make transactions and evaluate_default_values optional parameters in Project dataobject

### DIFF
--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -29,14 +29,14 @@ from qgis.PyQt.QtCore import QObject, pyqtSignal
 class Project(QObject):
     layer_added = pyqtSignal(str)
 
-    def __init__(self):
+    def __init__(self, auto_transaction=True, evaluate_default_values=True):
         QObject.__init__(self)
         self.crs = None
         self.name = 'Not set'
         self.layers = List[Layer]
         self.legend = LegendGroup()
-        self.auto_transaction = True
-        self.evaluate_default_values = True
+        self.auto_transaction = auto_transaction
+        self.evaluate_default_values = evaluate_default_values
         self.relations = List[Relation]
 
     def add_layer(self, layer):

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -249,6 +249,7 @@ class Generator:
     def _get_relations_info(self, filter_layer_list=[]):
         return self._db_connector.get_relations_info(filter_layer_list)
 
+
 class DomainRelationGenerator:
     """TODO: remove when ili2db issue #19 is solved"""
 

--- a/projectgenerator/qgs_project_generator.py
+++ b/projectgenerator/qgs_project_generator.py
@@ -164,8 +164,8 @@ class QgsProjectGeneratorPlugin(QObject):
     def get_generator(self):
         return Generator
 
-    def create_project(self, layers, relations, legend):
-        project = Project()
+    def create_project(self, layers, relations, legend, auto_transaction=True, evaluate_default_values=True):
+        project = Project(auto_transaction, evaluate_default_values)
         project.layers = layers
         project.relations = relations
         project.legend = legend


### PR DESCRIPTION
We will need to turn transactions off in our LADM plugin, so having this as a parameter for `Project()` would be handy.