### PR TITLE
Use relation.id instead of referencedlayer.name as identificator

### DIFF
--- a/projectgenerator/libqgsprojectgen/dataobjects/form.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/form.py
@@ -96,11 +96,15 @@ class FormFieldWidget(object):
 
 class FormRelationWidget(object):
 
-    def __init__(self, name, relation):
-        self.name = name
+    def __init__(self, relation):
         self.relation = relation
 
     def create(self, parent, layer):
-        widget = QgsAttributeEditorRelation(
-            self.name, self.relation.id, parent)
+        try:
+            widget = QgsAttributeEditorRelation(
+               self.relation.id, parent)
+        except TypeError:
+            # Feed deprecated API for 3.0.0 and 3.0.1
+            widget = QgsAttributeEditorRelation(
+               self.relation.id, self.relation.id, parent)
         return widget

--- a/projectgenerator/libqgsprojectgen/dataobjects/layers.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/layers.py
@@ -89,8 +89,7 @@ class Layer(object):
             for relation in project.relations:
                 if relation.referenced_layer == self:
                     tab = FormTab(relation.referencing_layer.name)
-                    widget = FormRelationWidget(
-                        relation.id, relation)
+                    widget = FormRelationWidget(relation)
                     tab.addChild(widget)
                     self.__form.add_element(tab)
         else:

--- a/projectgenerator/libqgsprojectgen/dataobjects/layers.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/layers.py
@@ -90,7 +90,7 @@ class Layer(object):
                 if relation.referenced_layer == self:
                     tab = FormTab(relation.referencing_layer.name)
                     widget = FormRelationWidget(
-                        relation.referencing_layer.name, relation)
+                        relation.id, relation)
                     tab.addChild(widget)
                     self.__form.add_element(tab)
         else:


### PR DESCRIPTION
In the QGIS VectorLayerProperties at AttributesForm-configuration as an item in the drop-list, there will be the relation.id as label and identificator. 

Fix of Redmines #18290

**I had not the yet possiblity to test**


### Why that?
In that form we work always with relation-id and not with the relation-name (altough it's saved under "FieldNameRole" - this is because the other fields use the name as unique identificator). That's why we exepct in the name-variable of `mLayer->editFormConfig().tabs()``the relation-id. This is why the projectgenerator would write after this commit there the relation-id and not the referencedlayer-name. It would have worked if it would have written the relation-name (but only because it's equal to relation-id).

### Wieso das?
*Same explanation in german:*
In den LayerProperties wird immer mit der RelationId gearbeitet, nicht mit dem RelationName (selbst wenn das Feld, wo diese Id gespeichert wird wärend der Konfiguration unter FieldNameRole abgespeichert wird - dies weil die normalen Felder den Name als Identifikation verwenden, der - im Gegensatz zum RelationName - eindeutig ist). Diese Funktionsweise ist schon bei 2.18 *

Somit soll im QgsAttributeEditorElement ( aus dem mLayer->editFormConfig().tabs() ) auch in der name-Variable dieser als Id verwendete Name des Feldes bzw. die Id der Relation stehen. Dort steht aber im Falle eines Projektes, das vom Projektgenerator erstellt wird immer der ReferencingLayerName. Würde hier der RelationName drin stehen (was auch falsch wäre), würde es Funktionieren, da der Projektgenerator die RelationId als RelationName nimmt.

/* man könnte darüber nachdenken, den Name anstelle der Id in den TreeItems anzuzeigen. Müsste diesen aber zusätzlich zwischenspeichern.

### Possible QGIS improvements
We could think about to have the relation-name as the labeling of the items in the drag and the drop list. But then we would need to save them additionally in the item struct. It should be a second priority improvement because it's not fixing any bug. It's just the look.