### PR TITLE
Tests: Use openjdk-8-jre explicitly instead of 'default-jre' in Dockerfile

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -3,7 +3,7 @@ FROM  qgis/qgis:${QGIS_TEST_VERSION}
 MAINTAINER Matthias Kuhn <matthias@opengis.ch>
 
 RUN apt-get update && \
-    apt-get -y install default-jre 
+    apt-get -y install openjdk-8-jre
 
 ENV LANG=C.UTF-8
 


### PR DESCRIPTION
This avoids `java.lang.NoClassDefFoundError: javax/xml/ws/Holder` error from Java 9, which is now the `default-jre` in Ubuntu repositories.