### PR TITLE
Fix layer order code

### DIFF
--- a/projectgenerator/utils/qgis_utils.py
+++ b/projectgenerator/utils/qgis_utils.py
@@ -57,6 +57,7 @@ def get_suggested_index_for_layer(layer, group):
     no line layers in it, it will continue with the first index of polygons or
     groups. Always following the order given in the global layer_order variable.
     """
+    index = None
     for geometry_type in layer_order[layer_order.index(layer.geometryType()):]:  # slice from current until last
         index = get_first_index_for_geometry_type(geometry_type, group)
         if index is not None:

--- a/projectgenerator/utils/qgis_utils.py
+++ b/projectgenerator/utils/qgis_utils.py
@@ -31,7 +31,7 @@ layer_order = [QgsWkbTypes.PointGeometry,
 
 def get_first_index_for_geometry_type(geometry_type, group):
     """
-    Finds the first index (from top to botton) in the layer tree where a
+    Finds the first index (from top to bottom) in the layer tree where a
     specific layer type is found. This function works only for the given group.
     """
     tree_nodes = group.children()

--- a/projectgenerator/utils/qgis_utils.py
+++ b/projectgenerator/utils/qgis_utils.py
@@ -17,7 +17,11 @@
  ***************************************************************************/
 """
 
-from qgis.core import QgsLayerTreeNode, QgsWkbTypes
+from qgis.core import (
+    QgsLayerTreeNode,
+    QgsWkbTypes,
+    QgsMapLayer
+)
 
 layer_order = [QgsWkbTypes.PointGeometry,
                QgsWkbTypes.LineGeometry,
@@ -38,7 +42,7 @@ def get_first_index_for_geometry_type(geometry_type, group):
             return current
 
         layer = tree_node.layer()
-        if layer.geometryType() == geometry_type:
+        if layer.type() != QgsMapLayer.VectorLayer or layer.geometryType() == geometry_type:
             return current
 
     return None

--- a/projectgenerator/utils/qgis_utils.py
+++ b/projectgenerator/utils/qgis_utils.py
@@ -63,4 +63,8 @@ def get_suggested_index_for_layer(layer, group):
         if index is not None:
             break
 
-    return -1 if index is None else index  # Send it to the last position in layer tree
+    if index is None:
+        # Send it to the last position in layer tree
+        return -1
+    else:
+        return index

--- a/projectgenerator/utils/qgis_utils.py
+++ b/projectgenerator/utils/qgis_utils.py
@@ -28,6 +28,7 @@ layer_order = [QgsWkbTypes.PointGeometry,
                QgsWkbTypes.PolygonGeometry,
                QgsWkbTypes.UnknownGeometry]
 
+
 def get_first_index_for_geometry_type(geometry_type, group):
     """
     Finds the first index (from top to botton) in the layer tree where a
@@ -47,6 +48,7 @@ def get_first_index_for_geometry_type(geometry_type, group):
 
     return None
 
+
 def get_suggested_index_for_layer(layer, group):
     """
     Returns the index where a layer can be inserted, taking other layer types
@@ -55,9 +57,9 @@ def get_suggested_index_for_layer(layer, group):
     no line layers in it, it will continue with the first index of polygons or
     groups. Always following the order given in the global layer_order variable.
     """
-    for geometry_type in layer_order[layer_order.index(layer.geometryType()):]: # slice from current until last
+    for geometry_type in layer_order[layer_order.index(layer.geometryType()):]:  # slice from current until last
         index = get_first_index_for_geometry_type(geometry_type, group)
         if index is not None:
             break
 
-    return -1 if index is None else index # Send it to the last position in layer tree
+    return -1 if index is None else index  # Send it to the last position in layer tree


### PR DESCRIPTION
The layer order code has a couple of potential issues. Most prominent, when there is a raster layer involved. How does that look to you? Something that could be improved is that non-geometry layers are loaded behind rasters at the moment.
