### PR TITLE
Set related layer on n-m cardinality

### DIFF
--- a/projectgenerator/libqgsprojectgen/dataobjects/layers.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/layers.py
@@ -24,7 +24,7 @@ from qgis.PyQt.QtCore import QCoreApplication
 
 class Layer(object):
 
-    def __init__(self, provider, uri, name, geometry_column=None, wkb_type=QgsWkbTypes.Unknown, alias='', is_domain=False):
+    def __init__(self, provider, uri, name, geometry_column=None, wkb_type=QgsWkbTypes.Unknown, alias='', is_domain=False, is_nmrel=False):
         self.provider = provider
         self.uri = uri
         self.name = name
@@ -34,6 +34,7 @@ class Layer(object):
         self.__layer = None
         self.fields = list()
         self.is_domain = is_domain
+        self.is_nmrel = is_nmrel
         self.__form = Form()
 
     def dump(self):

--- a/projectgenerator/libqgsprojectgen/dataobjects/layers.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/layers.py
@@ -34,11 +34,11 @@ class Layer(object):
         self.__layer = None
         self.fields = list()
         self.is_domain = is_domain
-        """
-        If is_nmrel is set to true it is a junction table in a N:M relation.
-        Or in ili2db terms, the table is marked as ASSOCIATION in t_ili2db_table_prop.settings.
-        """
+
         self.is_nmrel = is_nmrel
+        """ If is_nmrel is set to true it is a junction table in a N:M relation.
+        Or in ili2db terms, the table is marked as ASSOCIATION in t_ili2db_table_prop.settings. """
+
         self.__form = Form()
 
     def dump(self):

--- a/projectgenerator/libqgsprojectgen/dataobjects/layers.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/layers.py
@@ -34,6 +34,10 @@ class Layer(object):
         self.__layer = None
         self.fields = list()
         self.is_domain = is_domain
+        """
+        If is_nmrel is set to true it is a junction table in a N:M relation.
+        Or in ili2db terms, the table is marked as ASSOCIATION in t_ili2db_table_prop.settings.
+        """
         self.is_nmrel = is_nmrel
         self.__form = Form()
 
@@ -42,6 +46,7 @@ class Layer(object):
         definition['provider'] = self.provider
         definition['uri'] = self.uri
         definition['isdomain'] = self.is_domain
+        definition['isnmrel'] = self.is_nmrel
         definition['form'] = self.__form.dump()
         return definition
 
@@ -49,6 +54,7 @@ class Layer(object):
         self.provider = definition['provider']
         self.uri = definition['uri']
         self.is_domain = definition['isdomain']
+        self.is_nmrel = definition['isnmrel']
         self.__form.load(definition['form'])
 
     def create(self):
@@ -63,8 +69,8 @@ class Layer(object):
 
         return self.__layer
 
-    def create_form(self, qgis_project):
-        edit_form = self.__form.create(self.__layer)
+    def create_form(self, project):
+        edit_form = self.__form.create(self, self.__layer, project)
         self.__layer.setEditFormConfig(edit_form)
 
     def post_generate(self, project):

--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -118,6 +118,16 @@ class Project(QObject):
         qgis_project.relationManager().setRelations(qgis_relations)
 
         for layer in self.layers:
+            for relation in self.relations:
+                if relation.referenced_layer == layer:
+                    # get other relations, that have the same referencing_layer and set the first as nm-rel
+                    for other_relation in self.relations:
+                        if other_relation.referencing_field != relation.referencing_field and other_relation.referencing_layer == relation.referencing_layer:
+                            edit_form_config = qgis_project.mapLayer(layer.layer.id()).editFormConfig()
+                            edit_form_config.setWidgetConfig(relation.id, {'nm-rel': other_relation.id})
+                            qgis_project.mapLayer(layer.layer.id()).setEditFormConfig(edit_form_config)
+                            break
+
             layer.create_form(qgis_project)
 
         if self.legend:

--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -118,19 +118,7 @@ class Project(QObject):
         qgis_project.relationManager().setRelations(qgis_relations)
 
         for layer in self.layers:
-            for relation in self.relations:
-                if relation.referenced_layer == layer:
-                    # get other relations, that have the same referencing_layer and set the first as nm-rel
-                    for other_relation in self.relations:
-                        if other_relation.referencing_field != relation.referencing_field and other_relation.referencing_layer == relation.referencing_layer:
-                            for ref_layer in self.layers:
-                                if other_relation.referencing_layer == ref_layer and ref_layer.layer.is_nmrel:
-                                    edit_form_config = qgis_project.mapLayer(layer.layer.id()).editFormConfig()
-                                    edit_form_config.setWidgetConfig(relation.id, {'nm-rel': other_relation.id})
-                                    qgis_project.mapLayer(layer.layer.id()).setEditFormConfig(edit_form_config)
-                                    break
-
-            layer.create_form(qgis_project)
+            layer.create_form(self)
 
         if self.legend:
             self.legend.create(qgis_project)

--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -123,10 +123,12 @@ class Project(QObject):
                     # get other relations, that have the same referencing_layer and set the first as nm-rel
                     for other_relation in self.relations:
                         if other_relation.referencing_field != relation.referencing_field and other_relation.referencing_layer == relation.referencing_layer:
-                            edit_form_config = qgis_project.mapLayer(layer.layer.id()).editFormConfig()
-                            edit_form_config.setWidgetConfig(relation.id, {'nm-rel': other_relation.id})
-                            qgis_project.mapLayer(layer.layer.id()).setEditFormConfig(edit_form_config)
-                            break
+                            for ref_layer in self.layers:
+                                if other_relation.referencing_layer == ref_layer and ref_layer.layer.is_nmrel:
+                                    edit_form_config = qgis_project.mapLayer(layer.layer.id()).editFormConfig()
+                                    edit_form_config.setWidgetConfig(relation.id, {'nm-rel': other_relation.id})
+                                    qgis_project.mapLayer(layer.layer.id()).setEditFormConfig(edit_form_config)
+                                    break
 
             layer.create_form(qgis_project)
 

--- a/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
@@ -55,7 +55,7 @@ class DBConnector:
                 geometry_column
                 srid
                 type  (Geometry Type)
-                is_domain
+                kind_settings
                 table_alias
                 model
         '''

--- a/projectgenerator/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -64,7 +64,7 @@ class GPKGConnector(DBConnector):
         interlis_joins = ''
 
         if self.metadata_exists():
-            interlis_fields = """p.setting AS is_domain,
+            interlis_fields = """p.setting AS kind_settings,
                 alias.setting AS table_alias,
                 substr(c.iliname, 0, instr(c.iliname, '.')) AS model,"""
             interlis_joins = """LEFT JOIN T_ILI2DB_TABLE_PROP p

--- a/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
@@ -77,7 +77,7 @@ class PGConnector(DBConnector):
 
     def get_tables_info(self):
         if self.schema:
-            is_domain_field = ''
+            kind_settings_field = ''
             domain_left_join = ''
             schema_where = ''
             table_alias = ''
@@ -86,7 +86,7 @@ class PGConnector(DBConnector):
             model_where = ''
 
             if self.metadata_exists():
-                is_domain_field = "p.setting AS is_domain,"
+                kind_settings_field = "p.setting AS kind_settings,"
                 table_alias = "alias.setting AS table_alias,"
                 model_name = "left(c.iliname, strpos(c.iliname, '.')-1) AS model,"
                 domain_left_join = """LEFT JOIN {}.t_ili2db_table_prop p
@@ -108,7 +108,7 @@ class PGConnector(DBConnector):
                           a.attname AS primary_key,
                           g.f_geometry_column AS geometry_column,
                           g.srid AS srid,
-                          {is_domain_field}
+                          {kind_settings_field}
                           {table_alias}
                           {model_name}
                           g.type AS simple_type,
@@ -129,7 +129,7 @@ class PGConnector(DBConnector):
                           ON ga.attrelid = i.indrelid
                           AND ga.attname = g.f_geometry_column
                         WHERE i.indisprimary {schema_where}
-            """.format(is_domain_field=is_domain_field, table_alias=table_alias,
+            """.format(kind_settings_field=kind_settings_field, table_alias=table_alias,
                        model_name=model_name, domain_left_join=domain_left_join,
                        alias_left_join=alias_left_join, model_where=model_where,
                        schema_where=schema_where))

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -89,9 +89,9 @@ class Generator:
                 )
 
             alias = record['table_alias'] if 'table_alias' in record else ''
-            is_domain = record['is_domain'] == 'ENUM' or record[
-                'is_domain'] == 'CATALOGUE' if 'is_domain' in record else False
-            is_nmrel = record['is_domain'] == 'ASSOCIATION' if 'is_domain' in record else False
+            is_domain = record['kind_settings'] == 'ENUM' or record[
+                'kind_settings'] == 'CATALOGUE' if 'kind_settings' in record else False
+            is_nmrel = record['kind_settings'] == 'ASSOCIATION' if 'kind_settings' in record else False
             layer = Layer(provider,
                           data_source_uri,
                           record['tablename'],

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -91,6 +91,7 @@ class Generator:
             alias = record['table_alias'] if 'table_alias' in record else ''
             is_domain = record['is_domain'] == 'ENUM' or record[
                 'is_domain'] == 'CATALOGUE' if 'is_domain' in record else False
+            is_nmrel = record['is_domain'] == 'ASSOCIATION' if 'is_domain' in record else False
             layer = Layer(provider,
                           data_source_uri,
                           record['tablename'],
@@ -98,7 +99,8 @@ class Generator:
                           QgsWkbTypes.parseType(
                               record['type']) or QgsWkbTypes.Unknown,
                           alias,
-                          is_domain)
+                          is_domain,
+                          is_nmrel)
 
             # Configure fields for current table
             fields_info = self.get_fields_info(record['tablename'])

--- a/projectgenerator/tests/test_projectgen.py
+++ b/projectgenerator/tests/test_projectgen.py
@@ -258,7 +258,7 @@ class TestProjectGen(unittest.TestCase):
 
         self.assertEqual(count, 1)
 
-    def test_rmrel_postgis(self):
+    def test_nmrel_postgis(self):
         importer = iliimporter.Importer()
         importer.tool_name = 'ili2pg'
         importer.configuration = iliimporter_config(importer.tool_name)
@@ -296,7 +296,7 @@ class TestProjectGen(unittest.TestCase):
                 self.assertFalse(map)
         self.assertEqual(count, 1)
 
-    def test_rmrel_geopackage(self):
+    def test_nmrel_geopackage(self):
 
         importer = iliimporter.Importer()
         importer.tool_name = 'ili2gpkg'

--- a/projectgenerator/tests/test_projectgen.py
+++ b/projectgenerator/tests/test_projectgen.py
@@ -258,16 +258,98 @@ class TestProjectGen(unittest.TestCase):
 
         self.assertEqual(count, 1)
 
+    def test_rmrel_postgis(self):
+        importer = iliimporter.Importer()
+        importer.tool_name = 'ili2pg'
+        importer.configuration = iliimporter_config(importer.tool_name)
+        importer.configuration.ilimodels = 'CoordSys'
+        importer.configuration.schema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
+            datetime.datetime.now())
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        self.assertEqual(importer.run(), iliimporter.Importer.SUCCESS)
+
+        generator = Generator(
+            'ili2pg', 'dbname=gis user=docker password=docker host=postgres', 'smart2', importer.configuration.schema)
+
+        available_layers = generator.layers()
+        relations = generator.relations(available_layers)
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        count = 0
+        for layer in available_layers:
+            if layer.name == 'geoellipsoidal':
+                count += 1
+                edit_form_config = layer.layer.editFormConfig()
+                map = edit_form_config.widgetConfig('lambert_from5_fkey')
+                self.assertEqual(map['nm-rel'], 'lambert_to5_fkey')
+                map = edit_form_config.widgetConfig('axis_geoellipsoidal_axis_fkey')
+                self.assertFalse(map)
+        self.assertEqual(count, 1)
+
+    def test_rmrel_geopackage(self):
+
+        importer = iliimporter.Importer()
+        importer.tool_name = 'ili2gpkg'
+        importer.configuration = iliimporter_config(importer.tool_name)
+        importer.configuration.ilimodels = 'CoordSys'
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath, 'tmp_import_gpkg.gpkg')
+        importer.configuration.epsg = 3116
+        importer.configuration.inheritance = 'smart2'
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        self.assertEqual(importer.run(), iliimporter.Importer.SUCCESS)
+
+        generator = Generator('ili2gpkg', importer.configuration.uri, 'smart2')
+
+        available_layers = generator.layers()
+        relations = generator.relations(available_layers)
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        count = 0
+        for layer in available_layers:
+            if layer.name == 'geoellipsoidal':
+                count += 1
+                edit_form_config = layer.layer.editFormConfig()
+                map = edit_form_config.widgetConfig('lambert_from5_geoellipsoidal_T_Id')
+                self.assertEqual(map['nm-rel'], 'lambert_to5_geocartesian2d_T_Id')
+                map = edit_form_config.widgetConfig('axis_geoellipsoidal_axis_geoellipsoidal_T_Id')
+                self.assertFalse(map)
+        self.assertEqual(count, 1)
+
     def print_info(self, text):
         print(text)
 
     def print_error(self, text):
         print(text)
 
+    def tearDown(self):
+        QgsProject.instance().removeAllMapLayers()
+
     @classmethod
     def tearDownClass(cls):
         """Run after all tests."""
         shutil.rmtree(cls.basetestpath, True)
+
 
 if __name__ == '__main__':
     nose2.main()


### PR DESCRIPTION
In the attribute form configuration we set the FK of the layer referencing to the same layer (networktable) as the current layer is.

So this would look like this:
![cardinality1](https://user-images.githubusercontent.com/28384354/38989483-6107e55c-43d7-11e8-945d-3d0d69ffed47.gif)
Instead of "Many to one" relation everywhere.

While the hinweisweiteredokumente_hinweis_fkey points to hinweisweiteredokumente_ursprung_fkey and hinweisweiteredokumente_ursprung_fkey to hinweisweiteredokumente_hinweis_fkey:
```
      <widgets>
        <widget name="hinweisweiteredokumente_hinweis_fkey">
          <config type="Map">
            <Option name="nm-rel" type="QString" value="hinweisweiteredokumente_ursprung_fkey"/>
          </config>
        </widget>
        <widget name="hinweisweiteredokumente_ursprung_fkey">
          <config type="Map">
            <Option name="nm-rel" type="QString" value="hinweisweiteredokumente_hinweis_fkey"/>
          </config>
        </widget>
        <widget name="multilingualuri_dokument_textimweb_fkey">
          <config type="Map">
            <Option name="nm-rel" type="QString" value="multilingualuri_amt_amtimweb_fkey"/>
          </config>
        </widget>
        <widget name="typ_dokument_vorschrift_fkey">
          <config type="Map">
            <Option name="nm-rel" type="QString" value="typ_dokument_typ_fkey"/>
          </config>
        </widget>
      </widgets>
```
Looks like this:
![cardinality2](https://user-images.githubusercontent.com/28384354/38989650-dd7d83c6-43d7-11e8-8563-650c9533b32d.gif)

Because I'm not to familiar with the project, can you tell me if this is what was requested @m-kuhn ?

Fix #24

**No tests yet in this PR**