### PR TITLE
Regex strings should be raw

### DIFF
--- a/projectgenerator/libili2db/ilicache.py
+++ b/projectgenerator/libili2db/ilicache.py
@@ -186,8 +186,8 @@ class IliCache(QObject):
         Parses an ili file returning models and version data
         '''
         models = list()
-        re_model = re.compile('\s*MODEL\s*([\w\d_-]+)\s.*')
-        re_model_version = re.compile('VERSION "([ \w\d\._-]+)".*')
+        re_model = re.compile(r'\s*MODEL\s*([\w\d_-]+)\s.*')
+        re_model_version = re.compile(r'VERSION "([ \w\d\._-]+)".*')
         with open(ilipath, 'r', encoding=encoding) as file:
             for line in file:
                 result = re_model.search(line)

--- a/projectgenerator/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -100,7 +100,7 @@ class GPKGConnector(DBConnector):
         filtered_records = records[:]
         for prefix_suffix in GPKG_FILTER_TABLES_MATCHING_PREFIX_SUFFIX:
             suffix_regexp = '(' + '|'.join(prefix_suffix['suffix'] ) + ')$' if prefix_suffix['suffix'] else ''
-            regexp = '{}[\W\w]+{}'.format(prefix_suffix['prefix'], suffix_regexp)
+            regexp = r'{}[\W\w]+{}'.format(prefix_suffix['prefix'], suffix_regexp)
 
             p = re.compile(regexp) # e.g., 'rtree_[\W\w]+_(geometry|geometry_node|geometry_parent|geometry_rowid)$'
             for record in records:
@@ -180,9 +180,9 @@ class GPKGConnector(DBConnector):
         # Create a mapping in the form of
         #
         # fieldname: (min, max)
-        res1 = re.findall('CHECK\((.*)\)', cursor.fetchone()[0])
+        res1 = re.findall(r'CHECK\((.*)\)', cursor.fetchone()[0])
         for res in res1:
-            res2 = re.search('(\w+) BETWEEN ([-?\d\.]+) AND ([-?\d\.]+)', res)
+            res2 = re.search(r'(\w+) BETWEEN ([-?\d\.]+) AND ([-?\d\.]+)', res)
             if res2:
                 constraint_mapping[res2.group(1)] = (
                     res2.group(2), res2.group(3))

--- a/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
@@ -150,7 +150,7 @@ class PGConnector(DBConnector):
 
     def _parse_pg_type(self, formatted_attr_type):
         if not self._geom_parse_regexp:
-            self._geom_parse_regexp = re.compile('geometry\((\w+?),\d+\)')
+            self._geom_parse_regexp = re.compile(r'geometry\((\w+?),\d+\)')
 
         typedef = None
 

--- a/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
@@ -223,7 +223,7 @@ class PGConnector(DBConnector):
         if self.schema:
             constraints_cur = self.conn.cursor(
                 cursor_factory=psycopg2.extras.DictCursor)
-            constraints_cur.execute("""
+            constraints_cur.execute(r"""
                 SELECT
                   consrc,
                   regexp_matches(consrc, '\(\((.*) >= [\'']?([-]?[\d\.]+)[\''::integer|numeric]*\) AND \((.*) <= [\'']?([-]?[\d\.]+)[\''::integer|numeric]*\)\)') AS check_details

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -105,7 +105,7 @@ class Generator:
             # Configure fields for current table
             fields_info = self.get_fields_info(record['tablename'])
             constraints_info = self.get_constraints_info(record['tablename'])
-            re_iliname = re.compile('^@iliname (.*)$')
+            re_iliname = re.compile(r'^@iliname (.*)$')
 
             for fielddef in fields_info:
                 column_name = fielddef['column_name']
@@ -398,14 +398,14 @@ class DomainRelationGenerator:
 
     def parse_model(self, model_content, domains):
         # MODEL Catastro_COL_ES_V_2_0_20170331 (es)
-        re_model = re.compile('\s*MODEL\s*([\w\d_-]+).*')
+        re_model = re.compile(r'\s*MODEL\s*([\w\d_-]+).*')
         # TOPIC Catastro_Registro [=]
-        re_topic = re.compile('\s*TOPIC\s*([\w\d_-]+).*')
-        re_structure = re.compile('\s*STRUCTURE\s*([\w\d_-]+)\s*\=.*') # STRUCTURE StructureName =
+        re_topic = re.compile(r'\s*TOPIC\s*([\w\d_-]+).*')
+        re_structure = re.compile(r'\s*STRUCTURE\s*([\w\d_-]+)\s*\=.*') # STRUCTURE StructureName =
         re_class = re.compile(
-            '\s*CLASS\s*([\w\d_-]+)\s*[EXTENDS]*\s*([\w\d_-]*).*')  # CLASS ClassName [EXTENDS] [BaseClassName] [=]
+            r'\s*CLASS\s*([\w\d_-]+)\s*[EXTENDS]*\s*([\w\d_-]*).*')  # CLASS ClassName [EXTENDS] [BaseClassName] [=]
         re_class_extends = re.compile(
-            '\s*EXTENDS\s*([\w\d_\-\.]+)\s*\=.*')  # EXTENDS BaseClassName =
+            r'\s*EXTENDS\s*([\w\d_\-\.]+)\s*\=.*')  # EXTENDS BaseClassName =
         re_end_structure = None  # END StructureName;
         re_end_class = None  # END ClassName;
         re_end_topic = None  # END TopicName;
@@ -427,7 +427,7 @@ class DomainRelationGenerator:
                 if result:
                     current_model = result.group(1)
                     re_end_model = re.compile(
-                        '.*END\s*{}\..*'.format(current_model))  # END TopicName;
+                        r'.*END\s*{}\..*'.format(current_model))  # END TopicName;
             else:  # There is a current_model
 
                 if not current_topic:
@@ -437,7 +437,7 @@ class DomainRelationGenerator:
                         if self.debug:
                             print("Topic encontrada", current_topic)
                         re_end_topic = re.compile(
-                            '\s*END\s*{};.*'.format(current_topic))  # END TopicName;
+                            r'\s*END\s*{};.*'.format(current_topic))  # END TopicName;
 
                         local_names = self.extract_local_names_from_domains(
                             domains, current_model, current_topic)
@@ -456,11 +456,11 @@ class DomainRelationGenerator:
                                 print("Structure encontrada", current_structure)
                             attributes = dict()
                             re_end_structure = re.compile(
-                                '\s*END\s*{};.*'.format(current_structure))  # END StructureName;
+                                r'\s*END\s*{};.*'.format(current_structure))  # END StructureName;
                             continue
                     else:
                         attribute = {res.group(1): d for d in domains_with_local for res in
-                                     [re.search('\s*([\w\d_-]+).*:.*\s{};.*'.format(d), line)] if res}
+                                     [re.search(r'\s*([\w\d_-]+).*:.*\s{};.*'.format(d), line)] if res}
 
                         if attribute:
                             if self.debug:
@@ -496,7 +496,7 @@ class DomainRelationGenerator:
                                 print("Class encontrada", current_class)
                             attributes = dict()
                             re_end_class = re.compile(
-                                '\s*END\s*{};.*'.format(current_class))  # END ClassName;
+                                r'\s*END\s*{};.*'.format(current_class))  # END ClassName;
                             bClassJustFound = True
 
                             # Possible EXTENDS
@@ -525,7 +525,7 @@ class DomainRelationGenerator:
                                 continue
 
                         attribute = {res.group(1): d for d in domains_with_local for res in
-                                     [re.search('\s*([\w\d_-]+).*:.*\s{};.*'.format(d), line)] if res}
+                                     [re.search(r'\s*([\w\d_-]+).*:.*\s{};.*'.format(d), line)] if res}
 
                         if attribute:
                             if self.debug:


### PR DESCRIPTION
We've got plenty of

```
 DeprecationWarning: invalid escape sequence \s
```

so let's change

```
'\s*CLASS match'
```
to
```
r'\s*CLASS match'
```