### PR TITLE
Specify external meta attributes file in GUI

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -348,6 +348,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
 
         configuration.epsg = self.epsg
         configuration.inheritance = self.ili2db_options.get_inheritance_type()
+        configuration.tomlfile = self.ili2db_options.get_toml_file()
 
         configuration.base_configuration = self.base_configuration
         if self.ili_file_line_edit.text().strip():

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -347,8 +347,8 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             configuration.dbfile = self.gpkg_file_line_edit.text().strip()
 
         configuration.epsg = self.epsg
-        configuration.inheritance = self.ili2db_options.get_inheritance_type()
-        configuration.tomlfile = self.ili2db_options.get_toml_file()
+        configuration.inheritance = self.ili2db_options.inheritance_type()
+        configuration.tomlfile = self.ili2db_options.toml_file()
 
         configuration.base_configuration = self.base_configuration
         if self.ili_file_line_edit.text().strip():

--- a/projectgenerator/gui/ili2db_options.py
+++ b/projectgenerator/gui/ili2db_options.py
@@ -20,11 +20,8 @@
 
 from projectgenerator.utils.qt_utils import (
     make_file_selector,
-    make_save_file_selector,
     Validators,
-    FileValidator,
-    NonEmptyStringValidator,
-    OverrideCursor
+    FileValidator
 )
 from qgis.PyQt.QtWidgets import QDialog
 from qgis.PyQt.QtCore import QSettings
@@ -66,21 +63,21 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         self.restore_configuration()
         self.done(1)
 
-    def get_inheritance_type(self):
+    def inheritance_type(self):
         if self.smart1_radio_button.isChecked():
             return 'smart1'
         else:
             return 'smart2'
 
-    def get_toml_file(self):
+    def toml_file(self):
         return self.toml_file_line_edit.text().strip()
 
     def save_configuration(self):
         settings = QSettings()
         settings.setValue(
-            'QgsProjectGenerator/ili2db/inheritance', self.get_inheritance_type())
+            'QgsProjectGenerator/ili2db/inheritance', self.inheritance_type())
         settings.setValue(
-            'QgsProjectGenerator/ili2db/tomlfile', self.get_toml_file())
+            'QgsProjectGenerator/ili2db/tomlfile', self.toml_file())
 
     def restore_configuration(self):
         settings = QSettings()

--- a/projectgenerator/libili2db/ili2dbconfig.py
+++ b/projectgenerator/libili2db/ili2dbconfig.py
@@ -113,6 +113,7 @@ class Ili2DbCommandConfiguration(object):
         self.tool_name = None
         self.ilifile = ''
         self.ilimodels = ''
+        self.tomlfile = ''
 
     @property
     def uri(self):
@@ -160,6 +161,9 @@ class Ili2DbCommandConfiguration(object):
 
         if self.ilimodels:
             args += ['--models', self.ilimodels]
+
+        if self.tomlfile:
+            args += ["--iliMetaAttrs", self.tomlfile]
 
         if self.ilifile:
             args += [self.ilifile]

--- a/projectgenerator/ui/ili2db_options.ui
+++ b/projectgenerator/ui/ili2db_options.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>418</width>
+    <width>552</width>
     <height>242</height>
    </rect>
   </property>
@@ -53,7 +53,7 @@ strategy. Concrete classes are mapped using a NewAndSubClass strategy.</string>
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -61,6 +61,45 @@ strategy. Concrete classes are mapped using a NewAndSubClass strategy.</string>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="toml_file_label">
+        <property name="text">
+         <string>Meta Attributes File</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="toml_file_line_edit">
+        <property name="toolTip">
+         <string>Choose optional TOML file</string>
+        </property>
+        <property name="placeholderText">
+         <string>[Optional]</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QToolButton" name="toml_file_browse_button">
+        <property name="toolTip">
+         <string>Browse TOML files</string>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Specify an external meta attributes file (.toml) in Advanced Options and provide it to ili2db by `--iliMetaAttrs`

![projectgen](https://user-images.githubusercontent.com/28384354/39691268-541a65b8-51dd-11e8-9f1e-4c3398c26677.png)

Issue #184

Missing:
- [ ] Test
- [ ] Docs
- [ ] loading toml-file from repository

 (Plus small fix, that on Advanced Options with "Cancel" the settings are not stored)