### PR TITLE
Make PostgreSQL estimated metadata parameter optional in Generator class (by default True)

### DIFF
--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -33,11 +33,12 @@ from .config import IGNORED_SCHEMAS, IGNORED_TABLES, IGNORED_FIELDNAMES, READONL
 class Generator:
     """Builds Project Generator objects from data extracted from databases."""
 
-    def __init__(self, tool_name, uri, inheritance, schema=None):
+    def __init__(self, tool_name, uri, inheritance, schema=None, pg_estimated_metadata=True):
         self.tool_name = tool_name
         self.uri = uri
         self.inheritance = inheritance
         self.schema = schema or None
+        self.pg_estimated_metadata = 'true' if pg_estimated_metadata else 'false'
         if self.tool_name == 'ili2pg':
             self._db_connector = pg_connector.PGConnector(uri, schema)
         elif self.tool_name == 'ili2gpkg':
@@ -65,9 +66,10 @@ class Generator:
             if self.tool_name == 'ili2pg':
                 provider = 'postgres'
                 if record['geometry_column']:
-                    data_source_uri = '{uri} key={primary_key} estimatedmetadata=true srid={srid} type={type} table="{schema}"."{table}" ({geometry_column})'.format(
+                    data_source_uri = '{uri} key={primary_key} estimatedmetadata={estimated_metadata} srid={srid} type={type} table="{schema}"."{table}" ({geometry_column})'.format(
                         uri=self.uri,
                         primary_key=record['primary_key'],
+                        estimated_metadata=self.pg_estimated_metadata,
                         srid=record['srid'],
                         type=record['type'],
                         schema=record['schemaname'],


### PR DESCRIPTION
Several tools from our LADM plugin simply don't work as expected because the number of features in the database doesn't match the number of features QGIS returns when `estimatedmetadata` is `True`.

This PR allows us to switch that parameter off, while avoiding to alter the current behaviour for the rest of Project Generator users.

I would say this is a critical issue for us.

**Example 1:**

 + A layer in the database contains several features but QGIS returns `0` when calling `layer.featureCount()`.
 + A tool initially checks whether the layer has features or not. If no features are found, the tool does not continue.
 + Since QGIS returns `0` for `layer.featureCount()`, the tool does nothing beyond the first check, generating confusion for the user, who may be even seeing spatial data on QGIS canvas.

**Example 2:**

 + There is no data stored in the layer, but QGIS says (because of the estimated metadata parameter) the layer does have data! 

![estimatedmetadata_1](https://user-images.githubusercontent.com/652785/39873840-a652975a-5431-11e8-950f-c255b7ae51e5.png)

 + When a tool does its check, the layer passes it and the tool continues (QGIS says there is data), but when the tool does its real job, for example, creating a Spatial Index, QGIS throws an exception (`QSpatialIndex` requires a layer with data).

![estimatedmetadata_2](https://user-images.githubusercontent.com/652785/39873841-a6c60d02-5431-11e8-970b-623468dea73c.png)

