### PR TITLE
Run tests on specified QGIS version

### DIFF
--- a/.docker/docker-compose.travis.yml
+++ b/.docker/docker-compose.travis.yml
@@ -9,6 +9,8 @@ services:
     build:
       context: ..
       dockerfile: ./.docker/Dockerfile
+      args:
+        QGIS_TEST_VERSION: ${QGIS_TEST_VERSION}
     tty: true
     volumes:
       - ${TRAVIS_BUILD_DIR}:/usr/src


### PR DESCRIPTION
Previously all tests would run on master and none on release-3_0.