### PR TITLE
Allow ignoring groups (nodes) when ordering new layers 

### DIFF
--- a/projectgenerator/libqgsprojectgen/dataobjects/legend.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/legend.py
@@ -26,10 +26,14 @@ from projectgenerator.utils.qgis_utils import get_suggested_index_for_layer
 
 class LegendGroup(object):
 
-    def __init__(self, name=None, expanded=True):
+    def __init__(self, name=None, expanded=True, ignore_node_names=[]):
         self.name = name
         self.items = list()
         self.expanded = expanded
+
+        # When adding layers in order, one could want to ignore nodes (e.g.,
+        # groups that should be always on top)
+        self.ignore_node_names = ignore_node_names
 
     def dump(self):
         definition = list()
@@ -67,7 +71,7 @@ class LegendGroup(object):
                 item.create(qgis_project, subgroup)
             else:
                 layer = item.layer
-                index = get_suggested_index_for_layer(layer, group) if layer.isSpatial() else 0
+                index = get_suggested_index_for_layer(layer, group, self.ignore_node_names) if layer.isSpatial() else 0
                 group.insertLayer(index, layer)
 
     def is_empty(self):

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -211,8 +211,8 @@ class Generator:
 
         return relations
 
-    def legend(self, layers):
-        legend = LegendGroup(QCoreApplication.translate('LegendGroup', 'root'))
+    def legend(self, layers, ignore_node_names=[]):
+        legend = LegendGroup(QCoreApplication.translate('LegendGroup', 'root'), ignore_node_names=ignore_node_names)
         tables = LegendGroup(
             QCoreApplication.translate('LegendGroup', 'tables'))
         domains = LegendGroup(QCoreApplication.translate(

--- a/projectgenerator/utils/qgis_utils.py
+++ b/projectgenerator/utils/qgis_utils.py
@@ -27,7 +27,7 @@ layer_order = ['point',  #QgsWkbTypes.PointGeometry
                'unknown']  # Anything else like geometry collections or plugin layers
 
 
-def get_first_index_for_layer_type(layer_type, group):
+def get_first_index_for_layer_type(layer_type, group, ignore_node_names=[]):
     """
     Finds the first index (from top to bottom) in the layer tree where a
     specific layer type is found. This function works only for the given group.
@@ -35,6 +35,10 @@ def get_first_index_for_layer_type(layer_type, group):
     tree_nodes = group.children()
 
     for current, tree_node in enumerate(tree_nodes):
+        if tree_node.name() in ignore_node_names:
+            # Some groups (e.g., validation errors) might be useful on a
+            # specific position (e.g., at the top), so, skip it to get indices
+            continue
         if tree_node.nodeType() == QgsLayerTreeNode.NodeGroup and layer_type != 'unknown':
             return None
         elif tree_node.nodeType() == QgsLayerTreeNode.NodeGroup and layer_type == 'unknown':
@@ -48,7 +52,7 @@ def get_first_index_for_layer_type(layer_type, group):
     return None
 
 
-def get_suggested_index_for_layer(layer, group):
+def get_suggested_index_for_layer(layer, group, ignore_node_names=[]):
     """
     Returns the index where a layer can be inserted, taking other layer types
     into account. For instance, if a line layer is given, this function will
@@ -61,7 +65,7 @@ def get_suggested_index_for_layer(layer, group):
     indices = []
     index = None
     for layer_type in layer_order[layer_order.index(get_layer_type(layer)):]:  # Slice from current until last
-        index = get_first_index_for_layer_type(layer_type, group)
+        index = get_first_index_for_layer_type(layer_type, group, ignore_node_names)
         if index is not None:
             indices.append(index)
 


### PR DESCRIPTION
This PR makes the ordering of new layers more flexible, e.g., ignoring certain groups that should be always on top, such as a group of topology errors. 

The introduced parameter is optional, so current users won't see any change in behaviour and also there won't be anything to adjust in other parts of Project Generator.

From the 'Asistente LADM_COL' plugin we pass the group name we would like to ignore when creating the legend and that's all we need.