### PR TITLE
Fix GPKG save file selector

### DIFF
--- a/projectgenerator/utils/qt_utils.py
+++ b/projectgenerator/utils/qt_utils.py
@@ -54,6 +54,9 @@ def selectFileNameToSave(line_edit_widget, title, file_filter, parent, extension
     filename, matched_filter = QFileDialog.getSaveFileName(parent, title, line_edit_widget.text(), file_filter)
     extension_valid = False
 
+    if not extensions:
+        extensions = [extension]
+
     if extensions:
         extension_valid = any(filename.endswith(ext) for ext in extensions)
 
@@ -65,7 +68,7 @@ def selectFileNameToSave(line_edit_widget, title, file_filter, parent, extension
 
 def make_save_file_selector(widget, title=QCoreApplication.translate('projectgenerator', 'Open File'),
                             file_filter=QCoreApplication.translate('projectgenerator', 'Any file(*)'), parent=None, extension='', extensions=None):
-    return partial(selectFileNameToSave, line_edit_widget=widget, title=title, file_filter=file_filter, parent=parent, extension=extension)
+    return partial(selectFileNameToSave, line_edit_widget=widget, title=title, file_filter=file_filter, parent=parent, extension=extension, extensions=extensions)
 
 
 def selectFolder(line_edit_widget, title, parent):


### PR DESCRIPTION
- Avoid error when selecting a GPKG file to save.
- Avoid appending '.gpkg' extension when not needed.

Problems introduced in https://github.com/opengisch/projectgenerator/commit/0c240b9567e4797c3638312947f31ec1d79a450b 