### PR TITLE
Avoid showing General tab as default in settings

### DIFF
--- a/projectgenerator/ui/options.ui
+++ b/projectgenerator/ui/options.ui
@@ -23,7 +23,7 @@
    <item row="3" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">


### PR DESCRIPTION
That always means an extra click for users, since we have no options in General.