### PR TITLE
Improve usability while adding paths in custom model dir dialog

### DIFF
--- a/projectgenerator/gui/custom_model_dir.py
+++ b/projectgenerator/gui/custom_model_dir.py
@@ -57,6 +57,8 @@ class CustomModelDirDialog(QDialog, DIALOG_UI):
         item = QListWidgetItem()
         self.set_flags(item)
         self.model_dir_list.addItem(item)
+        self.model_dir_list.setCurrentItem(item)
+        self.browse_dir()
 
     def remove_model_dir(self):
         for item in self.model_dir_list.selectedItems():


### PR DESCRIPTION
A minor modification is made to improve the usability in the add custom model dir functionality, so that in a single click to button "Add" we create a new list element and open the file explorer dialog to immediately set a path for it. 

This saves a couple of clicks for users.