### PR TITLE
Allow adding new features in relation reference widgets

### DIFF
--- a/projectgenerator/libqgsprojectgen/dataobjects/project.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/project.py
@@ -111,9 +111,19 @@ class Project(QObject):
                     'ShowOpenFormButton': False
                 }
                 )
-                referencing_layer = rel.referencingLayer()
-                referencing_layer.setEditorWidgetSetup(
-                    rel.referencingFields()[0], editor_widget_setup)
+            else:
+                editor_widget_setup = QgsEditorWidgetSetup('RelationReference', {
+                    'Relation': rel.id(),
+                    'ShowForm': False,
+                    'OrderByValue': True,
+                    'ShowOpenFormButton': False,
+                    'AllowAddFeatures': True
+                }
+                                                           )
+
+            referencing_layer = rel.referencingLayer()
+            referencing_layer.setEditorWidgetSetup(
+                rel.referencingFields()[0], editor_widget_setup)
 
         qgis_project.relationManager().setRelations(qgis_relations)
 


### PR DESCRIPTION
Let's take "Planerischer Gewässerschutz" as an example.
When creating a new "gwszone", a "status" needs to be defined. By default, no "status" is available, so one can draw a "gwszone" but will realize that he cannot save because "status" is mandatory but no options are available. So far one had to quit, go to the table, add a status, restart.
Now it's possible to add a new status directly from there.

Fix #197 