### PR TITLE
Improvements for BAG OF ENUM

### DIFF
--- a/projectgenerator/libqgsprojectgen/generator/domain_relations_generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/domain_relations_generator.py
@@ -208,27 +208,30 @@ class DomainRelationGenerator:
                             if classes_ili_pg[structure] in layer_map.keys() and domains_ili_pg[ilidomain] in layer_map.keys() and \
                                 classes_ili_pg[structure] in attrs_ili_pg_owner:
 
-                                if classes_ili_pg[class_name] in bags_of_enum:
-                                    bags_of_enum[classes_ili_pg[class_name]][iliattr_dbattr_mapping[attribute]] = [
-                                        layer_map[classes_ili_pg[class_name]][0],
-                                        cardinality,
-                                        layer_map[domains_ili_pg[ilidomain]][0],
-                                        self._db_connector.iliCodeName,
-                                        self._db_connector.dispName
-                                    ]
-                                else:
-                                    bags_of_enum[classes_ili_pg[class_name]] = {
-                                        iliattr_dbattr_mapping[attribute]:
-                                            [
-                                                layer_map[classes_ili_pg[class_name]][0],
-                                                cardinality,
-                                                layer_map[domains_ili_pg[ilidomain]][0],
-                                                self._db_connector.iliCodeName,
-                                                self._db_connector.dispName
-                                            ]
-                                    }
-                                if self.debug:
-                                    print("BAG OF ENUM!!!", classes_ili_pg[class_name], iliattr_dbattr_mapping[attribute], cardinality, domains_ili_pg[ilidomain])
+                                for layer in layer_map[classes_ili_pg[class_name]]:
+                                    layer_unique_name = "{}_{}".format(classes_ili_pg[class_name], layer.geometry_column)
+                                    if layer_unique_name in bags_of_enum:
+                                        bags_of_enum[layer_unique_name][iliattr_dbattr_mapping[attribute]] = [
+                                            layer,
+                                            cardinality,
+                                            # Domains shouldn't be repeated in layers list, so get the first and only element
+                                            layer_map[domains_ili_pg[ilidomain]][0],
+                                            self._db_connector.iliCodeName,
+                                            self._db_connector.dispName
+                                        ]
+                                    else:
+                                        bags_of_enum[layer_unique_name] = {
+                                            iliattr_dbattr_mapping[attribute]:
+                                                [
+                                                    layer,
+                                                    cardinality,
+                                                    layer_map[domains_ili_pg[ilidomain]][0],
+                                                    self._db_connector.iliCodeName,
+                                                    self._db_connector.dispName
+                                                ]
+                                        }
+                                    if self.debug:
+                                        print("BAG OF ENUM!!!", layer_unique_name, iliattr_dbattr_mapping[attribute], cardinality, domains_ili_pg[ilidomain])
 
         return (relations, bags_of_enum)
 

--- a/projectgenerator/qgs_project_generator.py
+++ b/projectgenerator/qgs_project_generator.py
@@ -165,6 +165,21 @@ class QgsProjectGeneratorPlugin(QObject):
         return Generator
 
     def create_project(self, layers, relations, bags_of_enum, legend, auto_transaction=True, evaluate_default_values=True):
+        """
+        Expose the main functionality from Project Generator to other plugins,
+        namely, create a QGIS project from objects obtained from the Generator
+        class.
+
+        :param layers: layers object from generator.layers
+        :param relations: relations object obtained from generator.relations
+        :param bags_of_enum: bags_of_enum object from generator.relations
+        :param legend: legend object obtained from generator.legend
+        :param auto_transaction: whether transactions should be enabled or not
+                                 when editing layers from supported DB like PG
+        :param evaluate_default_values: should default values be evaluated on
+                                        provider side when requested and not
+                                        when committed. (from QGIS docs)
+        """
         project = Project(auto_transaction, evaluate_default_values)
         project.layers = layers
         project.relations = relations

--- a/projectgenerator/qgs_project_generator.py
+++ b/projectgenerator/qgs_project_generator.py
@@ -164,10 +164,11 @@ class QgsProjectGeneratorPlugin(QObject):
     def get_generator(self):
         return Generator
 
-    def create_project(self, layers, relations, legend, auto_transaction=True, evaluate_default_values=True):
+    def create_project(self, layers, relations, bags_of_enum, legend, auto_transaction=True, evaluate_default_values=True):
         project = Project(auto_transaction, evaluate_default_values)
         project.layers = layers
         project.relations = relations
+        project.bags_of_enum = bags_of_enum
         project.legend = legend
         project.post_generate()
         qgis_project = QgsProject.instance()

--- a/projectgenerator/tests/test_domain_class_relations.py
+++ b/projectgenerator/tests/test_domain_class_relations.py
@@ -438,15 +438,15 @@ class TestDomainClassRelation(unittest.TestCase):
 
         # Test BAGs OF ENUM
         expected_bags_of_enum = [
-            ['erholungsinfrastruktur_punktobjekt', 'typ', '1..*', 'ei_punkt_typen', 'ilicode', 'dispname'],
-            ['erholungsinfrastruktur_punktobjekt', 'bewirtschaftung', '1..*', 'ei_bewirtschaftungen', 'ilicode', 'dispname'],
-            ['erholungsinfrastruktur_linienobjekt', 'typ', '1..*', 'ei_linie_typen', 'ilicode', 'dispname'],
-            ['erholungsinfrastruktur_linienobjekt', 'bewirtschaftung', '1..*', 'ei_bewirtschaftungen', 'ilicode', 'dispname'],
-            ['naturschutzinfrastruktur_punktobjekt', 'typ', '1..*', 'ni_punkt_typen', 'ilicode', 'dispname'],
-            ['naturschutzinfrastruktur_punktobjekt', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'ilicode', 'dispname'],
-            ['naturschutzinfrastruktur_linienobjekt', 'typ', '1..*', 'ni_linie_typen', 'ilicode', 'dispname'],
-            ['naturschutzinfrastruktur_linienobjekt', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'ilicode', 'dispname'],
-            ['naturschutzrelevantes_objekt_ohne_schutzstatus', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'ilicode', 'dispname']
+            ['erholungsinfrastruktur_punktobjekt_geometrie', 'typ', '1..*', 'ei_punkt_typen', 'ilicode', 'dispname'],
+            ['erholungsinfrastruktur_punktobjekt_geometrie', 'bewirtschaftung', '1..*', 'ei_bewirtschaftungen', 'ilicode', 'dispname'],
+            ['erholungsinfrastruktur_linienobjekt_geometrie', 'typ', '1..*', 'ei_linie_typen', 'ilicode', 'dispname'],
+            ['erholungsinfrastruktur_linienobjekt_geometrie', 'bewirtschaftung', '1..*', 'ei_bewirtschaftungen', 'ilicode', 'dispname'],
+            ['naturschutzinfrastruktur_punktobjekt_geometrie', 'typ', '1..*', 'ni_punkt_typen', 'ilicode', 'dispname'],
+            ['naturschutzinfrastruktur_punktobjekt_geometrie', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'ilicode', 'dispname'],
+            ['naturschutzinfrastruktur_linienobjekt_geometrie', 'typ', '1..*', 'ni_linie_typen', 'ilicode', 'dispname'],
+            ['naturschutzinfrastruktur_linienobjekt_geometrie', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'ilicode', 'dispname'],
+            ['naturschutzrelevantes_objekt_ohne_schutzstatus_geometrie', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'ilicode', 'dispname']
         ]
 
         count = 0
@@ -550,15 +550,15 @@ class TestDomainClassRelation(unittest.TestCase):
 
         # Test BAGs OF ENUM
         expected_bags_of_enum = [
-            ['erholungsinfrastruktur_punktobjekt', 'typ', '1..*', 'ei_punkt_typen', 'iliCode', 'dispName'],
-            ['erholungsinfrastruktur_punktobjekt', 'bewirtschaftung', '1..*', 'ei_bewirtschaftungen', 'iliCode', 'dispName'],
-            ['erholungsinfrastruktur_linienobjekt', 'typ', '1..*', 'ei_linie_typen', 'iliCode', 'dispName'],
-            ['erholungsinfrastruktur_linienobjekt', 'bewirtschaftung', '1..*', 'ei_bewirtschaftungen', 'iliCode', 'dispName'],
-            ['naturschutzinfrastruktur_punktobjekt', 'typ', '1..*', 'ni_punkt_typen', 'iliCode', 'dispName'],
-            ['naturschutzinfrastruktur_punktobjekt', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'iliCode', 'dispName'],
-            ['naturschutzinfrastruktur_linienobjekt', 'typ', '1..*', 'ni_linie_typen', 'iliCode', 'dispName'],
-            ['naturschutzinfrastruktur_linienobjekt', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'iliCode', 'dispName'],
-            ['naturschutzrelevantes_objekt_ohne_schutzstatus', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'iliCode', 'dispName']
+            ['erholungsinfrastruktur_punktobjekt_geometrie', 'typ', '1..*', 'ei_punkt_typen', 'iliCode', 'dispName'],
+            ['erholungsinfrastruktur_punktobjekt_geometrie', 'bewirtschaftung', '1..*', 'ei_bewirtschaftungen', 'iliCode', 'dispName'],
+            ['erholungsinfrastruktur_linienobjekt_geometrie', 'typ', '1..*', 'ei_linie_typen', 'iliCode', 'dispName'],
+            ['erholungsinfrastruktur_linienobjekt_geometrie', 'bewirtschaftung', '1..*', 'ei_bewirtschaftungen', 'iliCode', 'dispName'],
+            ['naturschutzinfrastruktur_punktobjekt_geometrie', 'typ', '1..*', 'ni_punkt_typen', 'iliCode', 'dispName'],
+            ['naturschutzinfrastruktur_punktobjekt_geometrie', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'iliCode', 'dispName'],
+            ['naturschutzinfrastruktur_linienobjekt_geometrie', 'typ', '1..*', 'ni_linie_typen', 'iliCode', 'dispName'],
+            ['naturschutzinfrastruktur_linienobjekt_geometrie', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'iliCode', 'dispName'],
+            ['naturschutzrelevantes_objekt_ohne_schutzstatus_geometrie', 'bewirtschaftung', '1..*', 'ns_bewirtschaftungen', 'iliCode', 'dispName']
         ]
 
         count = 0
@@ -627,8 +627,10 @@ class TestDomainClassRelation(unittest.TestCase):
 
         # Test BAGs OF ENUM
         expected_bags_of_enum = [
-            ['belasteter_standort', 'deponietyp', '0..*', 'deponietyp', 'ilicode', 'dispname'],
-            ['belasteter_standort', 'untersuchungsmassnahmen', '1..*', 'untersmassn', 'ilicode', 'dispname']
+            ['belasteter_standort_geo_lage_punkt', 'deponietyp', '0..*', 'deponietyp', 'ilicode', 'dispname'],
+            ['belasteter_standort_geo_lage_punkt', 'untersuchungsmassnahmen', '1..*', 'untersmassn', 'ilicode', 'dispname'],
+            ['belasteter_standort_geo_lage_polygon', 'deponietyp', '0..*', 'deponietyp', 'ilicode', 'dispname'],
+            ['belasteter_standort_geo_lage_polygon', 'untersuchungsmassnahmen', '1..*', 'untersmassn', 'ilicode', 'dispname']
         ]
 
         count = 0
@@ -642,7 +644,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 value_field = bag_of_enum_info[4]
                 self.assertIn([layer_name, attribute, cardinality, domain_table.name, key_field, value_field], expected_bags_of_enum)
 
-        self.assertEqual(count, 2)
+        self.assertEqual(count, 4)
 
 
     def test_domain_structure_relations_KbS_LV95_V1_3_geopackage(self):
@@ -697,8 +699,10 @@ class TestDomainClassRelation(unittest.TestCase):
 
         # Test BAGs OF ENUM
         expected_bags_of_enum = [
-            ['belasteter_standort', 'deponietyp', '0..*', 'deponietyp', 'iliCode', 'dispName'],
-            ['belasteter_standort', 'untersuchungsmassnahmen', '1..*', 'untersmassn', 'iliCode', 'dispName']
+            ['belasteter_standort_geo_lage_punkt', 'deponietyp', '0..*', 'deponietyp', 'iliCode', 'dispName'],
+            ['belasteter_standort_geo_lage_punkt', 'untersuchungsmassnahmen', '1..*', 'untersmassn', 'iliCode', 'dispName'],
+            ['belasteter_standort_geo_lage_polygon', 'deponietyp', '0..*', 'deponietyp', 'iliCode', 'dispName'],
+            ['belasteter_standort_geo_lage_polygon', 'untersuchungsmassnahmen', '1..*', 'untersmassn', 'iliCode', 'dispName']
         ]
 
         count = 0


### PR DESCRIPTION
 + [x] Configure BAG OF ENUM for tables with more than one geometry column.
 + [x] Use the meta-attribute `mapping=ARRAY` from meta-attrs table.
 + [x] Add more checks for bags of enum configuration for the case where a list of layers is given. 
 + [x] Adjust the exposed `create_project` method to work with bags of enums.