### PR TITLE
Make create import tid optional

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -357,6 +357,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         configuration.inheritance = self.ili2db_options.inheritance_type()
         configuration.tomlfile = self.ili2db_options.toml_file()
         configuration.create_basket_col = self.ili2db_options.create_basket_col()
+        configuration.create_import_tid = self.ili2db_options.create_import_tid()
 
         configuration.base_configuration = self.base_configuration
         if self.ili_file_line_edit.text().strip():

--- a/projectgenerator/gui/ili2db_options.py
+++ b/projectgenerator/gui/ili2db_options.py
@@ -66,6 +66,9 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         self.restore_configuration()
         self.done(1)
 
+    def create_import_tid(self):
+        return self.create_import_tid_checkbox.isChecked()
+
     def create_basket_col(self):
         return self.create_basket_col_checkbox.isChecked()
 
@@ -92,6 +95,7 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         settings.setValue(
             self.toml_file_key, self.toml_file())
         settings.setValue('QgsProjectGenerator/ili2db/create_basket_col', self.create_basket_col())
+        settings.setValue('QgsProjectGenerator/ili2db/create_import_tid', self.create_import_tid())
 
     def restore_configuration(self):
         settings = QSettings()
@@ -102,7 +106,9 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         else:
             self.smart2_radio_button.setChecked(True)
         create_basket_col = settings.value('QgsProjectGenerator/ili2db/create_basket_col', defaultValue=False, type=bool)
+        create_import_tid = settings.value('QgsProjectGenerator/ili2db/create_import_tid', defaultValue=True, type=bool)
 
         self.create_basket_col_checkbox.setChecked(create_basket_col)
+        self.create_import_tid_checkbox.setChecked(create_import_tid)
         self.toml_file_line_edit.setText(
             settings.value(self.toml_file_key))

--- a/projectgenerator/gui/import_data.py
+++ b/projectgenerator/gui/import_data.py
@@ -262,6 +262,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         configuration.ilimodels = self.ili_models_line_edit.text().strip()
         configuration.inheritance = self.ili2db_options.inheritance_type()
         configuration.create_basket_col = self.ili2db_options.create_basket_col()
+        configuration.create_import_tid = self.ili2db_options.create_import_tid()
         configuration.base_configuration = self.base_configuration
 
         return configuration

--- a/projectgenerator/libili2db/ili2dbconfig.py
+++ b/projectgenerator/libili2db/ili2dbconfig.py
@@ -196,6 +196,7 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         super().__init__()
         self.inheritance = 'smart1'
         self.create_basket_col = False
+        self.create_import_tid = True
         self.epsg = 21781  # Default EPSG code in ili2pg
 
     def to_ili2db_args(self, hide_password=False, with_action=True):
@@ -222,7 +223,9 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         args += ["--createFk"]
         args += ["--createFkIdx"]
         args += ["--createMetaInfo"]
-        args += ["--importTid"]
+
+        if self.create_import_tid:
+            args += ["--importTid"]
 
         if self.inheritance == 'smart1':
             args += ["--smart1Inheritance"]

--- a/projectgenerator/ui/ili2db_options.ui
+++ b/projectgenerator/ui/ili2db_options.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>552</width>
-    <height>290</height>
+    <height>320</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -53,7 +53,7 @@ strategy. Concrete classes are mapped using a NewAndSubClass strategy.</string>
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -63,7 +63,7 @@ strategy. Concrete classes are mapped using a NewAndSubClass strategy.</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QFrame" name="frame">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
@@ -115,6 +115,25 @@ strategy. Concrete classes are mapped using a NewAndSubClass strategy.</string>
         </property>
         <property name="text">
          <string>Create Basket Column</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Create Import Tid</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="create_import_tid_checkbox">
+        <property name="text">
+         <string>Create Import Tid</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/projectgenerator/ui/ili2db_options.ui
+++ b/projectgenerator/ui/ili2db_options.ui
@@ -129,6 +129,9 @@ strategy. Concrete classes are mapped using a NewAndSubClass strategy.</string>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
        <widget class="QCheckBox" name="create_import_tid_checkbox">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Creates a new column t_ili_tid in all classes, which is mandatory and should be unique, not only for across the current database, but across the whole system.&lt;/p&gt;&lt;p&gt;Normally you should not enable this option directly, but rely on the INTERLIS model and ili2db. The former should have a line enabling OIDs (preferably with UUIDs) and the latter will make sure the database updates the new column every time a new record is created.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Warning&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If this option is enabled, it is required to make sure that this column is filled with unique values. If the column is not filled, you would not be able to export the data to XTF.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="text">
          <string>Create Import Tid</string>
         </property>


### PR DESCRIPTION
This allows users to choose between create import tid column (`t_ili_tid`) on the data base (`True` by default):

![imagen](https://user-images.githubusercontent.com/25961499/45644707-f8a75c80-ba83-11e8-8776-03dd35e7af20.png)
