### PR TITLE
Set map canvas extent to one obtained from the model (t_ili2db_column_prop table)

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -314,6 +314,8 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
                     self.canvas.setExtent(rectangle)
                     self.canvas.refresh()
                     break
+                else:
+                    continue
 
             self.buttonBox.clear()
             self.buttonBox.setEnabled(True)

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -60,7 +60,12 @@ from qgis.PyQt.QtCore import (
 from qgis.core import (
     QgsProject,
     QgsCoordinateReferenceSystem,
-    Qgis
+    Qgis,
+    QgsRectangle,
+    QgsPointXY,
+    QgsWkbTypes,
+    QgsPolygon,
+    QgsGeometry
 )
 from qgis.gui import (
     QgsMessageBar,
@@ -297,6 +302,18 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
 
             self.print_info(self.tr('Generating QGIS project…'))
             project.create(None, qgis_project)
+
+            for layer in project.layers:
+                if layer.extent is not None:
+                    extent_values = layer.extent.split(';')
+                    print(extent_values[0], extent_values[1], extent_values[2], extent_values[3])
+                    rectangle = QgsRectangle(float(extent_values[0]), float(extent_values[1]), float(extent_values[2]),
+                                             float(extent_values[3]))
+                    print(rectangle)
+                    self.canvas = self.iface.mapCanvas()
+                    self.canvas.setExtent(rectangle)
+                    self.canvas.refresh()
+                    break
 
             self.buttonBox.clear()
             self.buttonBox.setEnabled(True)

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -61,11 +61,7 @@ from qgis.core import (
     QgsProject,
     QgsCoordinateReferenceSystem,
     Qgis,
-    QgsRectangle,
-    QgsPointXY,
-    QgsWkbTypes,
-    QgsPolygon,
-    QgsGeometry
+    QgsRectangle
 )
 from qgis.gui import (
     QgsMessageBar,
@@ -303,19 +299,18 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             self.print_info(self.tr('Generating QGIS project…'))
             project.create(None, qgis_project)
 
+            # Set the extent of the mapCanvas from the first layer extent found
             for layer in project.layers:
                 if layer.extent is not None:
                     extent_values = layer.extent.split(';')
-                    print(extent_values[0], extent_values[1], extent_values[2], extent_values[3])
-                    rectangle = QgsRectangle(float(extent_values[0]), float(extent_values[1]), float(extent_values[2]),
-                                             float(extent_values[3]))
-                    print(rectangle)
-                    self.canvas = self.iface.mapCanvas()
-                    self.canvas.setExtent(rectangle)
-                    self.canvas.refresh()
+                    rectangle = QgsRectangle(
+                                    float(extent_values[0]),
+                                    float(extent_values[1]),
+                                    float(extent_values[2]),
+                                    float(extent_values[3]))
+                    self.iface.mapCanvas().setExtent(rectangle)
+                    self.iface.mapCanvas().refresh()
                     break
-                else:
-                    continue
 
             self.buttonBox.clear()
             self.buttonBox.setEnabled(True)

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -60,8 +60,7 @@ from qgis.PyQt.QtCore import (
 from qgis.core import (
     QgsProject,
     QgsCoordinateReferenceSystem,
-    Qgis,
-    QgsRectangle
+    Qgis
 )
 from qgis.gui import (
     QgsMessageBar,
@@ -302,13 +301,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             # Set the extent of the mapCanvas from the first layer extent found
             for layer in project.layers:
                 if layer.extent is not None:
-                    extent_values = layer.extent.split(';')
-                    rectangle = QgsRectangle(
-                                    float(extent_values[0]),
-                                    float(extent_values[1]),
-                                    float(extent_values[2]),
-                                    float(extent_values[3]))
-                    self.iface.mapCanvas().setExtent(rectangle)
+                    self.iface.mapCanvas().setExtent(layer.extent)
                     self.iface.mapCanvas().refresh()
                     break
 

--- a/projectgenerator/libqgsprojectgen/dataobjects/layers.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/layers.py
@@ -17,8 +17,18 @@
  *                                                                         *
  ***************************************************************************/
 """
-from .form import Form, FormTab, FormRelationWidget, FormFieldWidget
-from qgis.core import QgsVectorLayer, QgsDataSourceUri, QgsWkbTypes
+from .form import (
+    Form,
+    FormTab,
+    FormRelationWidget,
+    FormFieldWidget
+)
+from qgis.core import (
+    QgsVectorLayer,
+    QgsDataSourceUri,
+    QgsWkbTypes,
+    QgsRectangle
+)
 from qgis.PyQt.QtCore import QCoreApplication
 
 
@@ -28,6 +38,13 @@ class Layer(object):
         self.provider = provider
         self.uri = uri
         self.name = name
+        if extent is not None:
+            extent_coords = extent.split(';')
+            extent = QgsRectangle(
+                        float(extent_coords[0]),
+                        float(extent_coords[1]),
+                        float(extent_coords[2]),
+                        float(extent_coords[3]))
         self.extent = extent
         self.geometry_column = geometry_column
         self.wkb_type = wkb_type

--- a/projectgenerator/libqgsprojectgen/dataobjects/layers.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/layers.py
@@ -24,10 +24,11 @@ from qgis.PyQt.QtCore import QCoreApplication
 
 class Layer(object):
 
-    def __init__(self, provider, uri, name, geometry_column=None, wkb_type=QgsWkbTypes.Unknown, alias=None, is_domain=False, is_structure=False, is_nmrel=False, display_expression=None):
+    def __init__(self, provider, uri, name, extent, geometry_column=None, wkb_type=QgsWkbTypes.Unknown, alias=None, is_domain=False, is_structure=False, is_nmrel=False, display_expression=None):
         self.provider = provider
         self.uri = uri
         self.name = name
+        self.extent = extent
         self.geometry_column = geometry_column
         self.wkb_type = wkb_type
         self.alias = alias

--- a/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
@@ -58,7 +58,7 @@ class DBConnector:
                 type  (Geometry Type)
                 kind_settings
                 ili_name
-                extent (insert coordinates xmin, ymin, xmax, ymax)
+                extent [a string: "xmin;ymin;xmax;ymax"]
                 table_alias
                 model
         '''

--- a/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
@@ -58,6 +58,7 @@ class DBConnector:
                 type  (Geometry Type)
                 kind_settings
                 ili_name
+                extent (insert coordinates xmin, ymin, xmax, ymax)
                 table_alias
                 model
         '''

--- a/projectgenerator/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -76,6 +76,23 @@ class GPKGConnector(DBConnector):
             interlis_fields = """p.setting AS kind_settings,
                 alias.setting AS table_alias,
                 c.iliname AS ili_name,
+                (
+                SELECT GROUP_CONCAT("setting", ';') FROM (
+                    SELECT tablename, setting
+                    FROM T_ILI2DB_COLUMN_PROP AS cprop
+                    LEFT JOIN gpkg_geometry_columns g
+                    ON cprop.tablename == g.table_name
+                        WHERE cprop."tag" IN ('ch.ehi.ili2db.c1Min', 'ch.ehi.ili2db.c2Min',
+                         'ch.ehi.ili2db.c1Max', 'ch.ehi.ili2db.c2Max')
+                    ORDER BY CASE TAG
+                        WHEN 'ch.ehi.ili2db.c1Min' THEN 1
+                        WHEN 'ch.ehi.ili2db.c2Min' THEN 2
+                        WHEN 'ch.ehi.ili2db.c1Max' THEN 3
+                        WHEN 'ch.ehi.ili2db.c2Max' THEN 4
+                        END ASC
+                    ) WHERE g.geometry_type_name IS NOT NULL
+                    GROUP BY tablename
+                ) AS extent,
                 substr(c.iliname, 0, instr(c.iliname, '.')) AS model,"""
             interlis_joins = """LEFT JOIN T_ILI2DB_TABLE_PROP p
                    ON p.tablename = s.name

--- a/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
@@ -100,6 +100,7 @@ class PGConnector(DBConnector):
             schema_where = ''
             table_alias = ''
             ili_name = ''
+            extent = ''
             alias_left_join = ''
             model_name = ''
             model_where = ''

--- a/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
@@ -118,6 +118,7 @@ class PGConnector(DBConnector):
                         END)
                     FROM {}."t_ili2db_column_prop" AS cprop
                     WHERE tbls.tablename = cprop.tablename
+                    AND cprop.columnname = g.f_geometry_column
                     AND cprop."tag" IN ('ch.ehi.ili2db.c1Min', 'ch.ehi.ili2db.c2Min',
                      'ch.ehi.ili2db.c1Max', 'ch.ehi.ili2db.c2Max')
                 ) AS extent,""".format(self.schema)

--- a/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
@@ -108,6 +108,18 @@ class PGConnector(DBConnector):
                 kind_settings_field = "p.setting AS kind_settings,"
                 table_alias = "alias.setting AS table_alias,"
                 ili_name = "c.iliname AS ili_name,"
+                extent = """(
+                    SELECT string_agg(setting, ';' ORDER BY CASE
+                        WHEN cprop."tag"='ch.ehi.ili2db.c1Min' THEN 1
+                        WHEN cprop."tag"='ch.ehi.ili2db.c2Min' THEN 2
+                        WHEN cprop."tag"='ch.ehi.ili2db.c1Max' THEN 3
+                        WHEN cprop."tag"='ch.ehi.ili2db.c2Max' THEN 4
+                        END)
+                    FROM {}."t_ili2db_column_prop" AS cprop
+                    WHERE tbls.tablename = cprop.tablename
+                    AND cprop."tag" IN ('ch.ehi.ili2db.c1Min', 'ch.ehi.ili2db.c2Min',
+                     'ch.ehi.ili2db.c1Max', 'ch.ehi.ili2db.c2Max')
+                ) AS extent,""".format(self.schema)
                 model_name = "left(c.iliname, strpos(c.iliname, '.')-1) AS model,"
                 domain_left_join = """LEFT JOIN {}.t_ili2db_table_prop p
                               ON p.tablename = tbls.tablename
@@ -132,6 +144,7 @@ class PGConnector(DBConnector):
                           {table_alias}
                           {model_name}
                           {ili_name}
+                          {extent}
                           g.type AS simple_type,
                           format_type(ga.atttypid, ga.atttypmod) as formatted_type
                         FROM pg_catalog.pg_tables tbls
@@ -151,7 +164,7 @@ class PGConnector(DBConnector):
                           AND ga.attname = g.f_geometry_column
                         WHERE i.indisprimary {schema_where}
             """.format(kind_settings_field=kind_settings_field, table_alias=table_alias,
-                       model_name=model_name, ili_name=ili_name, domain_left_join=domain_left_join,
+                       model_name=model_name, ili_name=ili_name, extent=extent, domain_left_join=domain_left_join,
                        alias_left_join=alias_left_join, model_where=model_where,
                        schema_where=schema_where))
 

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -107,7 +107,7 @@ class Generator:
             layer = Layer(provider,
                           data_source_uri,
                           record['tablename'],
-                          record['extent'],
+                          record['extent'] if 'extent' in record else None,
                           record['geometry_column'],
                           QgsWkbTypes.parseType(
                               record['type']) or QgsWkbTypes.Unknown,

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -107,6 +107,7 @@ class Generator:
             layer = Layer(provider,
                           data_source_uri,
                           record['tablename'],
+                          record['extent'],
                           record['geometry_column'],
                           QgsWkbTypes.parseType(
                               record['type']) or QgsWkbTypes.Unknown,


### PR DESCRIPTION
We pick the first layer extent for setting the canvas extent. We could have used the union of all extents in the `t_ili2db_column_prop` table, but we didn't since the base geometry model is almost set in stone and all layers use the same definitions from such model. 

@m-kuhn What do you think about such approach? Do Swiss models use several base geometry models or extent definitions? 

2 tests added.

Fix #83 