### PR TITLE
Do not load duplicate model entries in GUI

### DIFF
--- a/projectgenerator/libili2db/ilicache.py
+++ b/projectgenerator/libili2db/ilicache.py
@@ -258,12 +258,6 @@ class IliModelItemModel(QStandardItemModel):
                 if any(model['name'] in s for s in names):
                     continue
 
-                # for modelname in self.data(int(Qt.DisplayRole)):
-                #     if modelname == model['name']:
-                #         name_in_list = True
-                # if name_in_list:
-                #     continue
-
                 item = QStandardItem()
                 item.setData(model['name'], int(Qt.DisplayRole))
                 item.setData(model['name'], int(Qt.EditRole))

--- a/projectgenerator/libili2db/ilicache.py
+++ b/projectgenerator/libili2db/ilicache.py
@@ -250,12 +250,19 @@ class IliModelItemModel(QStandardItemModel):
     def set_repositories(self, repositories):
         self.clear()
         row = 0
-
+        names = list()
+                
         for repository in repositories.values():
-            for model in repository:
 
-                if next((duplicate for duplicate in model if duplicate == model['name']), None) != None:
+            for model in repository:
+                if any(model['name'] in s for s in names):
                     continue
+
+                # for modelname in self.data(int(Qt.DisplayRole)):
+                #     if modelname == model['name']:
+                #         name_in_list = True
+                # if name_in_list:
+                #     continue
 
                 item = QStandardItem()
                 item.setData(model['name'], int(Qt.DisplayRole))
@@ -263,6 +270,7 @@ class IliModelItemModel(QStandardItemModel):
                 item.setData(model['repository'], int(IliModelItemModel.Roles.ILIREPO))
                 item.setData(model['version'], int(IliModelItemModel.Roles.VERSION))
 
+                names.append(model['name'])
                 self.appendRow(item)
                 row += 1
 

--- a/projectgenerator/libili2db/ilicache.py
+++ b/projectgenerator/libili2db/ilicache.py
@@ -255,6 +255,7 @@ class IliModelItemModel(QStandardItemModel):
         for repository in repositories.values():
 
             for model in repository:
+                # in case there is more than one version of the model with the same name, it shouldn't load it twice
                 if any(model['name'] in s for s in names):
                     continue
 

--- a/projectgenerator/libili2db/ilicache.py
+++ b/projectgenerator/libili2db/ilicache.py
@@ -253,6 +253,10 @@ class IliModelItemModel(QStandardItemModel):
 
         for repository in repositories.values():
             for model in repository:
+
+                if next((duplicate for duplicate in model if duplicate == model['name']), None) != None:
+                    continue
+
                 item = QStandardItem()
                 item.setData(model['name'], int(Qt.DisplayRole))
                 item.setData(model['name'], int(Qt.EditRole))


### PR DESCRIPTION
IMHO this is a solid solution, but I'm not sure if it could be nicer with something like `if any(model['name'] in s.data(int(Qt.DisplayRole)) for s in self):`...

#151 