### PR TITLE
Flexible completion dropdown on model lineedit

### DIFF
--- a/projectgenerator/gui/export.py
+++ b/projectgenerator/gui/export.py
@@ -22,7 +22,7 @@ import os
 import webbrowser
 import os.path
 
-from projectgenerator.gui.options import OptionsDialog
+from projectgenerator.gui.options import OptionsDialog, CompletionLineEdit
 from projectgenerator.gui.multiple_models import MultipleModelsDialog
 from projectgenerator.libili2db.iliexporter import JavaNotFoundError
 from projectgenerator.libili2db.ilicache import IliCache, ModelCompleterDelegate
@@ -94,6 +94,8 @@ class ExportDialog(QDialog, DIALOG_UI):
             self.validators.validate_line_edits)
         self.ili_models_line_edit.textChanged.emit(
             self.ili_models_line_edit.text())
+        self.ili_models_line_edit.textChanged.connect(self.complete_models_completer)
+        self.ili_models_line_edit.punched.connect(self.complete_models_completer)
         self.pg_host_line_edit.textChanged.connect(
             self.validators.validate_line_edits)
         self.pg_host_line_edit.textChanged.emit(self.pg_host_line_edit.text())
@@ -344,6 +346,13 @@ class ExportDialog(QDialog, DIALOG_UI):
                 self.base_configuration.save(settings)
         else:
             QDesktopServices.openUrl(link)
+
+    def complete_models_completer(self):
+        if not self.ili_models_line_edit.text():
+            self.ili_models_line_edit.completer().setCompletionMode(QCompleter.UnfilteredPopupCompletion)
+            self.ili_models_line_edit.completer().complete()
+        else:
+            self.ili_models_line_edit.completer().setCompletionMode(QCompleter.PopupCompletion)
 
     def update_models_completer(self):
         completer = QCompleter(self.ilicache.model, self.ili_models_line_edit)

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -157,6 +157,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
 
         self.ilicache = IliCache(self.base_configuration)
         self.refresh_ili_cache()
+        self.ili_models_line_edit.setPlaceholderText(self.tr('[Search model from repository]'))
 
         self.ili_file_line_edit.textChanged.connect(
             self.validators.validate_line_edits)
@@ -524,6 +525,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             self.refresh_ili_cache()
             models = self.ilicache.process_ili_file(self.ili_file_line_edit.text().strip())
             self.ili_models_line_edit.setText(models[-1]['name'])
+            self.ili_models_line_edit.setPlaceholderText(self.tr('[Search model from file]'))
         else:
             nonEmptyValidator = NonEmptyStringValidator()
             self.ili_models_line_edit.setValidator(nonEmptyValidator)
@@ -533,6 +535,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             # Update completer to add models from given ili file
             self.ilicache = IliCache(self.base_configuration)
             self.refresh_ili_cache()
+            self.ili_models_line_edit.setPlaceholderText(self.tr('[Search model from repository]'))
 
     def refresh_ili_cache(self):
         self.ilicache.new_message.connect(self.show_message)

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -525,7 +525,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             self.refresh_ili_cache()
             models = self.ilicache.process_ili_file(self.ili_file_line_edit.text().strip())
             self.ili_models_line_edit.setText(models[-1]['name'])
-            self.ili_models_line_edit.setPlaceholderText(self.tr('[Search model from file]'))
+            self.ili_models_line_edit.setPlaceholderText(models[-1]['name'])
         else:
             nonEmptyValidator = NonEmptyStringValidator()
             self.ili_models_line_edit.setValidator(nonEmptyValidator)

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -155,10 +155,8 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.ili_models_line_edit.textChanged.connect(self.complete_models_completer)
         self.ili_models_line_edit.punched.connect(self.complete_models_completer)
 
-        self.ilicache = IliCache(base_config)
-        self.update_models_completer()
-        self.ilicache.new_message.connect(self.show_message)
-        self.ilicache.refresh()
+        self.ilicache = IliCache(self.base_configuration)
+        self.refresh_ili_cache()
 
         self.ili_file_line_edit.textChanged.connect(
             self.validators.validate_line_edits)
@@ -522,17 +520,25 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
                 self.ili_models_line_edit.text())
 
             # Update completer to add models from given ili file
-            self.iliFileCache = IliCache(
+            self.ilicache = IliCache(
                 self.base_configuration, self.ili_file_line_edit.text().strip())
-            self.iliFileCache.new_message.connect(self.show_message)
-            self.iliFileCache.refresh()
-            models = self.iliFileCache.process_ili_file(self.ili_file_line_edit.text().strip())
+            self.refresh_ili_cache()
+            models = self.ilicache.process_ili_file(self.ili_file_line_edit.text().strip())
             self.ili_models_line_edit.setText(models[-1]['name'])
         else:
             nonEmptyValidator = NonEmptyStringValidator()
             self.ili_models_line_edit.setValidator(nonEmptyValidator)
             self.ili_models_line_edit.textChanged.emit(
                 self.ili_models_line_edit.text())
+
+            # Update completer to add models from given ili file
+            self.ilicache = IliCache(self.base_configuration)
+            self.refresh_ili_cache()
+
+    def refresh_ili_cache(self):
+        self.ilicache.new_message.connect(self.show_message)
+        self.ilicache.refresh()
+        self.update_models_completer()
 
     def complete_models_completer(self):
         if not self.ili_models_line_edit.text():

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -520,8 +520,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
                 self.ili_models_line_edit.text())
 
             # Update completer to add models from given ili file
-            self.ilicache = IliCache(
-                self.base_configuration, self.ili_file_line_edit.text().strip())
+            self.ilicache = IliCache(None, self.ili_file_line_edit.text().strip())
             self.refresh_ili_cache()
             models = self.ilicache.process_ili_file(self.ili_file_line_edit.text().strip())
             self.ili_models_line_edit.setText(models[-1]['name'])

--- a/projectgenerator/gui/import_data.py
+++ b/projectgenerator/gui/import_data.py
@@ -21,7 +21,7 @@
 import webbrowser
 
 from projectgenerator.gui.ili2db_options import Ili2dbOptionsDialog
-from projectgenerator.gui.options import OptionsDialog
+from projectgenerator.gui.options import OptionsDialog, CompletionLineEdit
 from projectgenerator.gui.multiple_models import MultipleModelsDialog
 from projectgenerator.libili2db.iliimporter import JavaNotFoundError
 from projectgenerator.libili2db.ilicache import IliCache, ModelCompleterDelegate
@@ -111,6 +111,8 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.gpkg_file_line_edit.setValidator(gpkgFileValidator)
 
         self.ili_models_line_edit.setPlaceholderText(self.tr('[Search model in repository]'))
+        self.ili_models_line_edit.textChanged.connect(self.complete_models_completer)
+        self.ili_models_line_edit.punched.connect(self.complete_models_completer)
         self.pg_host_line_edit.textChanged.connect(
             self.validators.validate_line_edits)
         self.pg_host_line_edit.textChanged.emit(self.pg_host_line_edit.text())
@@ -350,6 +352,13 @@ class ImportDataDialog(QDialog, DIALOG_UI):
                 self.base_configuration.save(settings)
         else:
             QDesktopServices.openUrl(link)
+
+    def complete_models_completer(self):
+        if not self.ili_models_line_edit.text():
+            self.ili_models_line_edit.completer().setCompletionMode(QCompleter.UnfilteredPopupCompletion)
+            self.ili_models_line_edit.completer().complete()
+        else:
+            self.ili_models_line_edit.completer().setCompletionMode(QCompleter.PopupCompletion)
 
     def update_models_completer(self):
         completer = QCompleter(self.ilicache.model, self.ili_models_line_edit)

--- a/projectgenerator/gui/options.py
+++ b/projectgenerator/gui/options.py
@@ -25,8 +25,8 @@ from projectgenerator.libili2db.ili2dbutils import get_ili2db_bin
 from projectgenerator.utils import get_ui_class
 from projectgenerator.utils import qt_utils
 from projectgenerator.gui.custom_model_dir import CustomModelDirDialog
-from qgis.PyQt.QtWidgets import QDialog
-from qgis.PyQt.QtCore import QLocale, QSettings
+from qgis.PyQt.QtWidgets import QDialog, QLineEdit
+from qgis.PyQt.QtCore import QLocale, QSettings, pyqtSignal
 
 from projectgenerator.utils.qt_utils import FileValidator, Validators
 
@@ -113,3 +113,20 @@ class OptionsDialog(QDialog, DIALOG_UI):
         command = '\n  '.join([executable] + config.to_ili2db_args())
 
         self.ili2db_options_textedit.setText(command)
+
+
+class CompletionLineEdit(QLineEdit):
+
+    punched = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super(CompletionLineEdit, self).__init__(parent)
+        self.readyToEdit = True
+
+    def focusInEvent(self, e):
+        super(CompletionLineEdit, self).focusInEvent(e)
+        self.punched.emit()
+
+    def mouseReleaseEvent(self, e):
+        super(CompletionLineEdit, self).mouseReleaseEvent(e)
+        self.punched.emit()

--- a/projectgenerator/libili2db/ilicache.py
+++ b/projectgenerator/libili2db/ilicache.py
@@ -66,11 +66,12 @@ class IliCache(QObject):
         self.model = IliModelItemModel()
 
     def refresh(self):
-        if not self.base_configuration is None:
-            for directory in self.base_configuration.model_directories:
-                self.process_model_directory(directory)
+        #if single_ili_file given, do not take models from repositories
         if not self.single_ili_file is None:
             self.process_single_ili_file()
+        elif not self.base_configuration is None:
+            for directory in self.base_configuration.model_directories:
+                self.process_model_directory(directory)
 
     def process_model_directory(self, path):
         if path[0] == '%':

--- a/projectgenerator/libili2db/ilicache.py
+++ b/projectgenerator/libili2db/ilicache.py
@@ -66,12 +66,11 @@ class IliCache(QObject):
         self.model = IliModelItemModel()
 
     def refresh(self):
-        #if single_ili_file given, do not take models from repositories
-        if not self.single_ili_file is None:
-            self.process_single_ili_file()
-        elif not self.base_configuration is None:
+        if not self.base_configuration is None:
             for directory in self.base_configuration.model_directories:
                 self.process_model_directory(directory)
+        if not self.single_ili_file is None:
+            self.process_single_ili_file()
 
     def process_model_directory(self, path):
         if path[0] == '%':

--- a/projectgenerator/ui/export.ui
+++ b/projectgenerator/ui/export.ui
@@ -88,7 +88,7 @@
            </spacer>
           </item>
           <item row="1" column="2" colspan="2">
-           <widget class="QLineEdit" name="ili_models_line_edit"/>
+           <widget class="CompletionLineEdit" name="ili_models_line_edit"/>
           </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label">
@@ -301,6 +301,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CompletionLineEdit</class>
+   <header>projectgenerator.gui.options</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>type_combo_box</tabstop>
   <tabstop>xtf_file_line_edit</tabstop>

--- a/projectgenerator/ui/generate_project.ui
+++ b/projectgenerator/ui/generate_project.ui
@@ -125,7 +125,7 @@
            </widget>
           </item>
           <item row="2" column="1" colspan="2">
-           <widget class="QLineEdit" name="ili_models_line_edit"/>
+           <widget class="QLineEdit" name="ili_models_line_edit_dummy"/>
           </item>
           <item row="0" column="1" colspan="2">
            <widget class="QLineEdit" name="ili_file_line_edit">
@@ -363,7 +363,7 @@
   <tabstop>type_combo_box</tabstop>
   <tabstop>ili_file_line_edit</tabstop>
   <tabstop>ili_file_browse_button</tabstop>
-  <tabstop>ili_models_line_edit</tabstop>
+  <tabstop>ili_models_line_edit_dummy</tabstop>
   <tabstop>multiple_models_button</tabstop>
   <tabstop>crsSelector</tabstop>
   <tabstop>ili2db_options_button</tabstop>

--- a/projectgenerator/ui/generate_project.ui
+++ b/projectgenerator/ui/generate_project.ui
@@ -125,7 +125,7 @@
            </widget>
           </item>
           <item row="2" column="1" colspan="2">
-           <widget class="QLineEdit" name="ili_models_line_edit_dummy"/>
+           <widget class="CompletionLineEdit" name="ili_models_line_edit"/>
           </item>
           <item row="0" column="1" colspan="2">
            <widget class="QLineEdit" name="ili_file_line_edit">
@@ -358,12 +358,17 @@
    <header>qgis.gui</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>CompletionLineEdit</class>
+   <header>projectgenerator.gui.options</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>type_combo_box</tabstop>
   <tabstop>ili_file_line_edit</tabstop>
   <tabstop>ili_file_browse_button</tabstop>
-  <tabstop>ili_models_line_edit_dummy</tabstop>
+  <tabstop>ili_models_line_edit</tabstop>
   <tabstop>multiple_models_button</tabstop>
   <tabstop>crsSelector</tabstop>
   <tabstop>ili2db_options_button</tabstop>

--- a/projectgenerator/ui/import_data.ui
+++ b/projectgenerator/ui/import_data.ui
@@ -128,7 +128,7 @@
            </widget>
           </item>
           <item row="1" column="2" colspan="2">
-           <widget class="QLineEdit" name="ili_models_line_edit"/>
+           <widget class="CompletionLineEdit" name="ili_models_line_edit"/>
           </item>
           <item row="0" column="2" colspan="2">
            <widget class="QLineEdit" name="xtf_file_line_edit"/>
@@ -328,6 +328,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CompletionLineEdit</class>
+   <header>projectgenerator.gui.options</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>type_combo_box</tabstop>
   <tabstop>xtf_file_line_edit</tabstop>


### PR DESCRIPTION
Means it shows the filtered list if you change the original text.
If you click inside a lineedit with content it does not show the list until you change something.
If you click inside an empty lineedit it shows the unfiltered list.
If you delete the text of the lineedit it shows the unfiltered list.

Looks kind of like this:

![select_completion](https://user-images.githubusercontent.com/28384354/45698869-55307780-bb69-11e8-992a-7a2eb7502efd.gif)

- [x] on Generate
- [x] on import
- [x] on export
- [x] fix ugly GUI
- [x] display only the models from ili-file

It's about #212