### PR TITLE
Avoid QGIS crash by calling processEvents() only when required

### DIFF
--- a/projectgenerator/gui/import_data.py
+++ b/projectgenerator/gui/import_data.py
@@ -221,7 +221,6 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.txtStdout.setTextColor(QColor('#2a2a2a'))
         self.txtStdout.append(text)
         self.advance_progress_bar_by_text(text)
-        QCoreApplication.processEvents()
 
     def on_process_started(self, command):
         self.disable()
@@ -392,7 +391,9 @@ class ImportDataDialog(QDialog, DIALOG_UI):
                 "https://opengisch.github.io/projectgenerator/docs/user-guide.html#import-an-interlis-transfer-file-xtf")
 
     def advance_progress_bar_by_text(self, text):
-        if text.strip() == 'Info: compile models…':
+        if text.strip() == 'Info: compile models...':
             self.progress_bar.setValue(50)
-        elif text.strip() == 'Info: create table structure…':
+            QCoreApplication.processEvents()
+        elif text.strip() == 'Info: create table structure...':
             self.progress_bar.setValue(75)
+            QCoreApplication.processEvents()


### PR DESCRIPTION
Also: Fix conditionals that weren't really working.

The crash happened on data Import, throwing this error: 

```
Stacktrace (piped through c++filt):
src/core/qgsmessagelog.cpp: 29: (logMessage) [1900ms] 2018-10-01T16:13:57 Qt[1] QSettings::value: Empty key passed
src/core/qgsmessagelog.cpp: 29: (logMessage) [120642ms] 2018-10-01T16:15:58 Python error[1] RecursionError: maximum recursion depth exceeded

Fatal Python error: Cannot recover from stack overflow.

Current thread 0x00007fa96cec9340 (most recent call first):
  File "/home/germap/.local/share/QGIS/QGIS3/profiles/default/python/plugins/projectgenerator/libili2db/iliimporter.py", line 133 in stderr_ready
  File "/home/germap/.local/share/QGIS/QGIS3/profiles/default/python/plugins/projectgenerator/gui/import_data.py", line 224 in on_stderr
```