### PR TITLE
Support database names with tblank spaces

### DIFF
--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -266,7 +266,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             if self.type_combo_box.currentData() == 'pg':
                 if not generator._postgis_exists():
                     self.txtStdout.setText(
-                        self.tr('The current database does not have PostGIS installed! Please install it before proceeding.'))
+                        self.tr('The current database does not have PostGIS installed! Please install it by running `CREATE EXTENSION postgis;` on the database before proceeding.'))
                     self.enable()
                     self.progress_bar.hide()
                     return

--- a/projectgenerator/gui/generate_project.py
+++ b/projectgenerator/gui/generate_project.py
@@ -199,6 +199,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
                     self.tr('Please set a database user before creating the project.'))
                 self.pg_user_line_edit.setFocus()
                 return
+
         elif self.type_combo_box.currentData() in ['ili2gpkg', 'gpkg']:
             if not configuration.dbfile or self.gpkg_file_line_edit.validator().validate(configuration.dbfile, 0)[0] != QValidator.Acceptable:
                 self.txtStdout.setText(
@@ -258,6 +259,14 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
                         self.tr('Source {} does not exist. Check connection parameters.').format(
                             'database' if self.type_combo_box.currentData() == 'gpkg' else 'schema'
                         ))
+                    self.enable()
+                    self.progress_bar.hide()
+                    return
+
+            if self.type_combo_box.currentData() == 'pg':
+                if not generator._postgis_exists():
+                    self.txtStdout.setText(
+                        self.tr('The current database does not have PostGIS installed! Please install it before proceeding.'))
                     self.enable()
                     self.progress_bar.hide()
                     return
@@ -354,7 +363,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             configuration.dbhost = self.pg_host_line_edit.text().strip()
             configuration.dbport = self.pg_port_line_edit.text().strip()
             configuration.dbusr = self.pg_user_line_edit.text().strip()
-            configuration.database = self.pg_database_line_edit.text().strip()
+            configuration.database = "'{}'".format(self.pg_database_line_edit.text().strip())
             configuration.dbschema = self.pg_schema_line_edit.text().strip().lower()
             configuration.dbpwd = self.pg_password_line_edit.text()
         elif self.type_combo_box.currentData() in ['ili2gpkg', 'gpkg']:
@@ -392,7 +401,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             settings.setValue(
                 'QgsProjectGenerator/ili2pg/user', configuration.dbusr)
             settings.setValue(
-                'QgsProjectGenerator/ili2pg/database', configuration.database)
+                'QgsProjectGenerator/ili2pg/database', configuration.database.strip("'"))
             settings.setValue(
                 'QgsProjectGenerator/ili2pg/schema', configuration.dbschema)
             settings.setValue(

--- a/projectgenerator/libili2db/ili2dbconfig.py
+++ b/projectgenerator/libili2db/ili2dbconfig.py
@@ -148,7 +148,7 @@ class Ili2DbCommandConfiguration(object):
                     args += ["--dbpwd", '******']
                 else:
                     args += ["--dbpwd", self.dbpwd]
-            args += ["--dbdatabase", self.database]
+            args += ["--dbdatabase", self.database.strip("'")]
             args += ["--dbschema",
                      self.dbschema or self.database]
         elif self.tool_name == 'ili2gpkg':

--- a/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/pg_connector.py
@@ -51,6 +51,17 @@ class PGConnector(DBConnector):
 
         return data_type
 
+    def _postgis_exists(self):
+        cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        cur.execute("""
+                    SELECT
+                        count(extversion)
+                    FROM pg_catalog.pg_extension
+                    WHERE extname='postgis'
+                    """)
+
+        return bool(cur.fetchone()[0])
+
     def db_or_schema_exists(self):
         if self.schema:
             cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -270,6 +270,9 @@ class Generator:
 
         return legend
 
+    def _postgis_exists(self):
+        return self._db_connector._postgis_exists()
+
     def db_or_schema_exists(self):
         return self._db_connector.db_or_schema_exists()
 


### PR DESCRIPTION
Hi @m-kuhn, our new colleague @jhonalex06 attempted to use Project Generator using a database name with blank spaces and it threw a Python error. So he fixed that in this PR. 

He also noticed that using databases without PostGIS in the Generate dialog (Source: 'PostGIS') was throwing an error, and then he also fixed it in this PR.

In summary, this PR:

 + Adds support for database names with blank spaces.
 + Handles the PostGIS doesn't exist case in Generate->Source:PostGIS.
